### PR TITLE
Add manifest-based level loader and destructible support

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,8 @@ import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
 import { spawnProjectile, updateProjectiles } from './projectiles.js';
+import { LevelLoader } from './levelLoader.js';
+import { BreakManager } from './breakManager.js';
 
 const clock = new THREE.Clock();
 
@@ -26,6 +28,13 @@ async function main() {
 
   await createCity(scene);
   createClouds(scene);
+
+  // Load additional level data (destructible props, etc.)
+  const breakManager = new BreakManager(scene);
+  const levelLoader = new LevelLoader(scene, { breakManager });
+  await levelLoader.loadManifest('/areas/demo/area_manifest.json');
+  // Expose to window for debugging
+  window.breakManager = breakManager;
 
   let monster = null;
   loadMonsterModel(scene, data => {

--- a/areas/demo/area_manifest.json
+++ b/areas/demo/area_manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "assets": {
+    "barrel_steel_intact": "/assets/props/barrel_steel_intact.glb",
+    "barrel_steel_chunks": "/assets/props/barrel_steel_chunks.glb"
+  },
+  "instances": [
+    {
+      "id": "demo_barrel",
+      "asset": "barrel_steel_intact",
+      "position": [0,0,0],
+      "rotationEuler": [0,0,0],
+      "scale": 1,
+      "tags": ["prop", "destructible"],
+      "meta": {
+        "health": 50,
+        "fractureId": "barrel_steel_chunks"
+      }
+    }
+  ]
+}

--- a/breakManager.js
+++ b/breakManager.js
@@ -1,0 +1,53 @@
+import * as THREE from 'three';
+
+// BreakManager handles swapping intact meshes with fractured versions
+// and tracking health of destructible objects. Physics integration is left
+// to the consumer; this class simply swaps meshes and exposes a hook for
+// applying impulses.
+export class BreakManager {
+  constructor(scene) {
+    this.scene = scene;
+    this.registry = new Map(); // id -> { object, health, fractureScene }
+  }
+
+  // Register a destructible object. `data` expects:
+  // { id, health, fractureScene }
+  register(object, data) {
+    const id = data.id;
+    this.registry.set(id, {
+      object,
+      health: data.health ?? 100,
+      fractureScene: data.fractureScene
+    });
+  }
+
+  // Apply damage to an object. Once health <= 0 the object is replaced with its chunks.
+  async onHit(id, damage = 10, impulse = new THREE.Vector3()) {
+    const entry = this.registry.get(id);
+    if (!entry) return;
+    entry.health -= damage;
+    if (entry.health > 0) return;
+
+    const { object, fractureScene } = entry;
+    this.registry.delete(id);
+    if (!fractureScene) return;
+
+    // Remove the intact mesh
+    if (object.parent) {
+      object.parent.remove(object);
+    }
+
+    // Clone chunk scene and add to world. A physics engine could be integrated
+    // here by iterating over children and creating rigid bodies.
+    const chunks = fractureScene.clone(true);
+    chunks.position.copy(object.position);
+    chunks.rotation.copy(object.rotation);
+    chunks.scale.copy(object.scale);
+    this.scene.add(chunks);
+
+    // Placeholder for applying impulse to chunks. Real physics should replace this.
+    chunks.children.forEach(child => {
+      child.userData.velocity = impulse.clone();
+    });
+  }
+}

--- a/levelLoader.js
+++ b/levelLoader.js
@@ -1,0 +1,69 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { BreakManager } from './breakManager.js';
+
+// LevelLoader loads a manifest describing assets and instances. It also
+// registers destructible objects with BreakManager so they can be swapped at
+// runtime when destroyed.
+export class LevelLoader {
+  constructor(scene, options = {}) {
+    this.scene = scene;
+    this.loader = new GLTFLoader();
+    this.assets = new Map();
+    this.breakManager = options.breakManager || new BreakManager(scene);
+  }
+
+  async loadManifest(url) {
+    const res = await fetch(url);
+    const manifest = await res.json();
+    await this._loadAssets(manifest.assets);
+    this._createInstances(manifest.instances);
+    return manifest;
+  }
+
+  async _loadAssets(assetMap) {
+    const entries = Object.entries(assetMap || {});
+    const promises = entries.map(async ([id, path]) => {
+      const gltf = await this.loader.loadAsync(path);
+      this.assets.set(id, gltf.scene);
+    });
+    await Promise.all(promises);
+  }
+
+  _createInstances(instances = []) {
+    instances.forEach(inst => {
+      const src = this.assets.get(inst.asset);
+      if (!src) return;
+      const obj = src.clone(true);
+
+      obj.position.fromArray(inst.position || [0, 0, 0]);
+      const r = inst.rotationEuler || [0, 0, 0];
+      obj.rotation.set(r[0], r[1], r[2]);
+      if (Array.isArray(inst.scale)) {
+        obj.scale.fromArray(inst.scale);
+      } else if (typeof inst.scale === 'number') {
+        obj.scale.setScalar(inst.scale);
+      }
+
+      obj.userData.id = inst.id;
+      obj.userData.tags = inst.tags || [];
+      obj.userData.meta = inst.meta || {};
+
+      this.scene.add(obj);
+
+      if (inst.meta && inst.meta.fractureId) {
+        const fractureScene = this.assets.get(inst.meta.fractureId);
+        this.breakManager.register(obj, {
+          id: inst.id,
+          health: inst.meta.health,
+          fractureScene
+        });
+      }
+    });
+  }
+
+  // Convenience hook to forward hit events to the break manager
+  onHit(id, damage, impulse) {
+    this.breakManager.onHit(id, damage, impulse);
+  }
+}

--- a/projectiles.js
+++ b/projectiles.js
@@ -70,6 +70,20 @@ export function updateProjectiles({
       }
     }
 
+    // Check destructible props loaded via LevelLoader
+    if (window.breakManager) {
+      for (const [id, data] of window.breakManager.registry.entries()) {
+        const targetBox = new THREE.Box3().setFromObject(data.object);
+        const projBox = new THREE.Box3().setFromObject(proj);
+        if (projBox.intersectsBox(targetBox)) {
+          window.breakManager.onHit(id, 25, proj.userData.velocity.clone());
+          scene.remove(proj);
+          projectiles.splice(i, 1);
+          break;
+        }
+      }
+    }
+
     const projBox = new THREE.Box3().setFromObject(proj);
     const localBox = new THREE.Box3().setFromObject(playerModel);
     if (projBox.intersectsBox(localBox) && age >= 80) {


### PR DESCRIPTION
## Summary
- add LevelLoader to spawn assets and instances from JSON manifest
- add BreakManager to swap destroyed meshes with fractured versions
- integrate loader into app and projectiles for destructible hits

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b8e6db26c832596b07eec5e265973