### PR TITLE
feat: replace player model with old man

### DIFF
--- a/characters/PlayerCharacter.js
+++ b/characters/PlayerCharacter.js
@@ -5,7 +5,14 @@ import * as THREE from "three";
 
 export class PlayerCharacter extends CharacterBase {
   constructor(username) {
-    const { model, nameLabel } = createPlayerModel(THREE, username);
+    const { model, nameLabel } = createPlayerModel(
+      THREE,
+      username,
+      ({ mixer, actions }) => {
+        this.mixer = mixer;
+        this.actions = actions;
+      }
+    );
     super(model);
     this.nameLabel = nameLabel;
   }


### PR DESCRIPTION
## Summary
- center old man model so it renders at player position
- slice single animation clip into idle/walk/run/jump/ledge actions and log them
- drive idle/walk/jump actions from controls

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cb34987c083258aadf511f3ecff7d