### PR TITLE
Fix player model scale and rotation pivot

### DIFF
--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -9,10 +9,12 @@ export function createPlayerModel(THREE, username, onLoad) {
     (gltf) => {
       const model = gltf.scene;
 
-      // Center the model at the origin so it appears at player coordinates
+      // Scale and center the model so it rotates around its midpoint
+      const scale = 0.01;
+      model.scale.set(scale, scale, scale);
       const box = new THREE.Box3().setFromObject(model);
       const center = box.getCenter(new THREE.Vector3());
-      model.position.set(-center.x, -box.min.y + 200, -center.z);
+      model.position.set(-center.x, -box.min.y, -center.z);
       playerGroup.add(model);
 
       const mixer = new THREE.AnimationMixer(model);


### PR DESCRIPTION
## Summary
- Scale the old man player model down for proper size
- Re-center the model so rotations pivot around its midpoint

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cbeebc29483259e04e0d3bd79748e