### PR TITLE
Add speech-synthesized voice lines for orc monster

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@
 import * as THREE from "three";
 import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { loadMonsterModel } from "./models/monsterModel.js";
+import { createOrcVoice } from "./orcVoice.js";
 import { createClouds, createCity, generateTerrainChunk } from "./worldGeneration.js";
 import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
@@ -45,6 +46,14 @@ async function main() {
     monster.userData.direction = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
     monster.userData.speed = 0.01;
     monster.userData.lastDirectionChange = Date.now();
+
+    const orcPhrases = [
+      "Lok'tar ogar!",
+      "Smash them!",
+      "For the Horde!",
+      "You're no match for me!"
+    ];
+    monster.userData.voice = createOrcVoice(orcPhrases);
   });
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -90,6 +90,7 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
       switchMonsterAnimation(monster, "Weapon");
       data.lastAttackTime = now;
       console.log(`👹 Monster attacked ${closestPlayer.id}`);
+      monster.userData.voice?.speakRandom();
 
       if (window.playerModel?.position) {
         const dist = monster.position.distanceTo(window.playerModel.position);

--- a/orcVoice.js
+++ b/orcVoice.js
@@ -1,0 +1,31 @@
+export function createOrcVoice(phrases = []) {
+  if (typeof window === 'undefined' || !window.speechSynthesis) {
+    return { speakRandom: () => {}, speak: () => {} };
+  }
+
+  const synth = window.speechSynthesis;
+  let voices = synth.getVoices();
+  if (!voices.length) {
+    synth.onvoiceschanged = () => {
+      voices = synth.getVoices();
+    };
+  }
+
+  function speak(text) {
+    const utter = new SpeechSynthesisUtterance(text);
+    utter.pitch = 0.4; // deep voice for orc
+    utter.rate = 0.9;
+    if (voices.length) {
+      utter.voice = voices[0];
+    }
+    synth.speak(utter);
+  }
+
+  function speakRandom() {
+    if (!phrases.length) return;
+    const phrase = phrases[Math.floor(Math.random() * phrases.length)];
+    speak(phrase);
+  }
+
+  return { speak, speakRandom };
+}


### PR DESCRIPTION
## Summary
- add `createOrcVoice` helper using Web Speech API to speak phrases with a low, orc-like pitch
- load orc phrases in `app.js` and attach voice to monster model
- trigger monster voice lines when attacking a player

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cdda0a138832596e485532c36edc8