### PR TITLE
Scale orc voice volume with distance

### DIFF
--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -90,11 +90,14 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
       switchMonsterAnimation(monster, "Weapon");
       data.lastAttackTime = now;
       console.log(`👹 Monster attacked ${closestPlayer.id}`);
-      monster.userData.voice?.speakRandom();
 
       if (window.playerModel?.position) {
-        const dist = monster.position.distanceTo(window.playerModel.position);
-        if (dist < 3.2 && !window.playerControls.isKnocked) {
+        const playerDist = monster.position.distanceTo(window.playerModel.position);
+        const maxHearingDistance = 20;
+        const volume = Math.max(0, 1 - playerDist / maxHearingDistance);
+        monster.userData.voice?.speakRandom(volume);
+
+        if (playerDist < 3.2 && !window.playerControls.isKnocked) {
           window.localHealth = Math.max(0, window.localHealth - 10);
           const knockbackDir = new THREE.Vector3()
             .subVectors(window.playerModel.position, monster.position)
@@ -109,7 +112,7 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
           window.playerControls.knockbackRotation = new THREE.Euler(Math.PI / 2, 0, 0, 'XYZ');
           window.playerControls.knockbackRotationAxis = right;
 
-          console.log(`👹 Monster attacks you! Distance: ${dist.toFixed(2)} | Health: ${window.localHealth.toFixed(1)}`);
+          console.log(`👹 Monster attacks you! Distance: ${playerDist.toFixed(2)} | Health: ${window.localHealth.toFixed(1)}`);
         }
       }
     }

--- a/orcVoice.js
+++ b/orcVoice.js
@@ -11,20 +11,21 @@ export function createOrcVoice(phrases = []) {
     };
   }
 
-  function speak(text) {
+  function speak(text, volume = 1) {
     const utter = new SpeechSynthesisUtterance(text);
     utter.pitch = 0.001; // deep voice for orc
     utter.rate = 0.2;
+    utter.volume = volume;
     if (voices.length) {
       utter.voice = voices[0];
     }
     synth.speak(utter);
   }
 
-  function speakRandom() {
+  function speakRandom(volume = 1) {
     if (!phrases.length) return;
     const phrase = phrases[Math.floor(Math.random() * phrases.length)];
-    speak(phrase);
+    speak(phrase, volume);
   }
 
   return { speak, speakRandom };


### PR DESCRIPTION
## Summary
- Allow orc speech to receive a volume parameter
- Scale orc voice volume based on distance to the player when attacking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce07a04c083258ea7232dc857b1c8