### PR TITLE
feat: ragdoll knockback when hit

### DIFF
--- a/projectiles.js
+++ b/projectiles.js
@@ -95,6 +95,11 @@ export function updateProjectiles({
         window.localHealth = Math.max(0, window.localHealth - 10);
         console.log(`❤️ Your Health: ${window.localHealth}`);
       }
+
+      if (window.playerControls) {
+        const impulse = vel.clone().multiplyScalar(5);
+        window.playerControls.applyKnockback(impulse);
+      }
     }
 
     if (monster) {


### PR DESCRIPTION
## Summary
- add knockback handler to PlayerControls that stops animations and calculates ragdoll rotation
- update movement loop to simulate falling and recovery after being hit
- trigger ragdoll knockback when projectiles strike the local player

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf2621bc4832595ba64fe84bc9fcb