### PR TITLE
Add friendly and enemy modes for monster

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,6 +45,7 @@ async function main() {
     monster.userData.direction = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
     monster.userData.speed = 0.025;
     monster.userData.lastDirectionChange = Date.now();
+    monster.userData.mode = "enemy"; // default behavior
 
     const orcPhrases = [
       "Uggghh",
@@ -54,6 +55,13 @@ async function main() {
     ];
     monster.userData.voice = createOrcVoice(orcPhrases);
   });
+
+  // Allow mode switching from console or other scripts
+  window.setMonsterMode = mode => {
+    if (monster && (mode === "friendly" || mode === "enemy")) {
+      monster.userData.mode = mode;
+    }
+  };
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });
   renderer.setSize(window.innerWidth, window.innerHeight);

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -50,6 +50,30 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
     return;
   }
 
+  // 🕊️ Friendly mode: wander around without attacking players
+  if (data.mode === "friendly") {
+    const delta = clock.getDelta();
+
+    // Change direction every few seconds to simulate wandering
+    if (now - data.lastDirectionChange > 2000) {
+      data.direction = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
+      data.lastDirectionChange = now;
+    }
+
+    const movement = data.direction.clone().multiplyScalar(data.speed);
+    monster.position.add(movement);
+
+    // Follow terrain height and face movement direction
+    const targetY = getTerrainHeightAt(monster.position.x, monster.position.z);
+    monster.position.y += (targetY - monster.position.y) * 0.2;
+    monster.lookAt(monster.position.clone().add(data.direction));
+
+    switchMonsterAnimation(monster, "Walk");
+
+    if (data.mixer) data.mixer.update(delta);
+    return; // ⛔ Skip enemy logic
+  }
+
   const allPlayers = [
     { id: 'local', model: playerModel },
     ...Object.entries(otherPlayers).map(([id, p]) => ({ id, model: p.model }))


### PR DESCRIPTION
## Summary
- Add `mode` flag to monster and helper to switch modes
- Implement friendly wandering behavior
- Enemy mode retains existing chase and attack logic

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689df0a8a4e48325a83b7f473c89ae2c