### PR TITLE
Fix player centering and hit animation

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -238,16 +238,14 @@ export class PlayerControls {
   applyKnockback(impulse) {
     this.isKnocked = true;
     this.knockbackVelocity.copy(impulse);
-    // this.knockbackRestYaw = this.playerModel.rotation.y;
-    const up = new THREE.Vector3(0, 1, 0);
-    const axis = new THREE.Vector3().crossVectors(up, impulse.clone().normalize());
-    if (axis.lengthSq() === 0) {
-      axis.set(1, 0, 0);
+    const actions = this.playerModel.userData.actions;
+    const current = this.playerModel.userData.currentAction;
+    const hitAction = actions?.hit;
+    if (hitAction) {
+      actions[current]?.fadeOut(0.1);
+      hitAction.reset().fadeIn(0.1).play();
+      this.playerModel.userData.currentAction = 'hit';
     }
-    // this.knockbackRotationAxis.copy(axis.normalize());
-    this.playerModel.userData.mixer?.stopAllAction();
-    this.playerModel.userData.actions?.hit?.play();
-    this.playerModel.userData.currentAction = 'hit';
   }
 
   processMovement() {
@@ -337,7 +335,9 @@ export class PlayerControls {
         this.isKnocked = false;
         this.velocity.set(0, 0, 0);
         this.playerModel.setRotationFromAxisAngle(new THREE.Vector3(0, 1, 0), this.playerModel.rotation.y);
-        this.playerModel.userData.actions?.idle?.play();
+        const actions = this.playerModel.userData.actions;
+        actions?.hit?.fadeOut(0.2);
+        actions?.idle?.reset().fadeIn(0.2).play();
         this.playerModel.userData.currentAction = 'idle';
         console.log("🤕 Got up");
       }
@@ -422,7 +422,9 @@ export class PlayerControls {
       this.knockbackVelocity.set(0, 0, 0);
       this.velocity.set(0, 0, 0);
       this.playerModel.rotation.set(0, this.knockbackRestYaw || this.playerModel.rotation.y, 0);
-      this.playerModel.userData.actions?.idle?.play();
+      const actions = this.playerModel.userData.actions;
+      actions?.hit?.fadeOut(0.2);
+      actions?.idle?.reset().fadeIn(0.2).play();
       this.playerModel.userData.currentAction = 'idle';
       console.log("🤕 Got up");
     }

--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -12,10 +12,17 @@ export function createPlayerModel(THREE, username, onLoad) {
       // Scale and center the model so it rotates around its midpoint
       const scale = 0.01;
       model.scale.set(scale, scale, scale);
+
+      // Center the FBX so rotations pivot around the model itself
+      model.updateMatrixWorld(true);
       const box = new THREE.Box3().setFromObject(model);
       const center = box.getCenter(new THREE.Vector3());
-      model.position.set(-center.x, -box.min.y-0.75, -center.z);
-      playerGroup.add(model);
+
+      // Offset the model inside a pivot group instead of shifting the mesh directly
+      const pivot = new THREE.Group();
+      pivot.position.set(-center.x, -box.min.y, -center.z);
+      pivot.add(model);
+      playerGroup.add(pivot);
 
       const mixer = new THREE.AnimationMixer(model);
       const actions = {};
@@ -42,7 +49,7 @@ export function createPlayerModel(THREE, username, onLoad) {
             (anim) => {
               const clip = anim.animations[0];
               const action = mixer.clipAction(clip);
-              if (name === 'jump') {
+              if (name === 'jump' || name === 'hit') {
                 action.loop = THREE.LoopOnce;
                 action.clampWhenFinished = true;
               }


### PR DESCRIPTION
## Summary
- center the old man model with a pivot group so direction changes no longer cause position jumps
- crossfade to one-shot hit animation and return to idle afterward

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689deff3687c8325a4931bbade74d30a