### PR TITLE
feat: add speech command support

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ import { getCookie, setCookie } from './utils.js';
 import { spawnProjectile, updateProjectiles } from './projectiles.js';
 import { LevelLoader } from './levelLoader.js';
 import { BreakManager } from './breakManager.js';
+import { initSpeechCommands } from './speechCommands.js';
 
 const clock = new THREE.Clock();
 
@@ -90,6 +91,14 @@ async function main() {
     projectiles
   });
   window.playerControls = playerControls;
+
+  // Initialize speech commands for voice-controlled actions
+  const speech = initSpeechCommands({
+    jump: () => playerControls.triggerJump(),
+    fire: () => playerControls.triggerFire(),
+    shoot: () => playerControls.triggerFire()
+  });
+  speech.start();
 
   const generatedChunks = new Set();
   const chunkSize = 50;

--- a/controls.js
+++ b/controls.js
@@ -565,6 +565,35 @@ export class PlayerControls {
     return this.playerModel;
   }
 
+  /**
+   * Trigger a jump action programmatically.
+   * Useful for alternative input methods like voice commands.
+   */
+  triggerJump() {
+    if (this.canJump) {
+      this.velocity.y = JUMP_FORCE;
+      this.canJump = false;
+    }
+  }
+
+  /**
+   * Trigger a projectile fire action programmatically.
+   * Useful for alternative input methods like voice commands.
+   */
+  triggerFire() {
+    const position = this.playerModel.position.clone().add(new THREE.Vector3(0, 0.7, 0));
+    const direction = new THREE.Vector3(0, 0, 1).applyEuler(this.playerModel.rotation);
+
+    this.multiplayer.send({
+      type: 'projectile',
+      id: this.multiplayer.getId(),
+      position: position.toArray(),
+      direction: direction.toArray()
+    });
+
+    this.spawnProjectile(this.scene, this.projectiles, position, direction);
+  }
+
   setupPointerLock() {
     this.domElement.addEventListener('click', () => {
       this.domElement.requestPointerLock();

--- a/speechCommands.js
+++ b/speechCommands.js
@@ -1,0 +1,56 @@
+export function initSpeechCommands(commands = {}) {
+  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    console.warn('Speech recognition not supported in this browser.');
+    return { start: () => {}, stop: () => {} };
+  }
+
+  const recognition = new SpeechRecognition();
+  recognition.continuous = true;
+  recognition.interimResults = false;
+  recognition.lang = 'en-US';
+
+  recognition.onresult = (event) => {
+    for (let i = event.resultIndex; i < event.results.length; i++) {
+      const result = event.results[i];
+      if (result.isFinal) {
+        const transcript = result[0].transcript.trim().toLowerCase();
+        Object.entries(commands).forEach(([phrase, callback]) => {
+          if (transcript.includes(phrase.toLowerCase())) {
+            try {
+              callback();
+            } catch (err) {
+              console.error('Error executing command for phrase', phrase, err);
+            }
+          }
+        });
+      }
+    }
+  };
+
+  recognition.onerror = (e) => {
+    console.error('Speech recognition error:', e);
+  };
+
+  let active = false;
+
+  recognition.onend = () => {
+    if (active) {
+      // Restart automatically to keep listening
+      recognition.start();
+    }
+  };
+
+  return {
+    start: () => {
+      active = true;
+      try { recognition.start(); } catch (err) {
+        console.error('Failed to start speech recognition:', err);
+      }
+    },
+    stop: () => {
+      active = false;
+      recognition.stop();
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add speech command engine using Web Speech API
- expose jump and fire helpers for voice-triggered actions
- wire up speech commands for jump and fire events

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689df0f572308325b1cdaed2e8c5921a