### PR TITLE
Fix projectile animation and projectile terrain height

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,6 +166,18 @@ async function main() {
       const position = new THREE.Vector3(...data.position);
       const direction = new THREE.Vector3(...data.direction);
       spawnProjectile(scene, projectiles, position, direction);
+
+      const shooter = otherPlayers[data.id];
+      if (shooter) {
+        const actions = shooter.model.userData.actions;
+        const current = shooter.model.userData.currentAction;
+        const projAction = actions?.projectile;
+        if (projAction) {
+          actions[current]?.fadeOut(0.1);
+          projAction.reset().fadeIn(0.1).play();
+          shooter.model.userData.currentAction = 'projectile';
+        }
+      }
     }
 
     if (data.type === "monster" && monster) {

--- a/controls.js
+++ b/controls.js
@@ -248,6 +248,15 @@ export class PlayerControls {
           direction: direction.toArray()
         });
 
+        const actions = this.playerModel.userData.actions;
+        const current = this.playerModel.userData.currentAction;
+        const projAction = actions?.projectile;
+        if (projAction) {
+          actions[current]?.fadeOut(0.1);
+          projAction.reset().fadeIn(0.1).play();
+          this.playerModel.userData.currentAction = 'projectile';
+        }
+
         this.spawnProjectile(this.scene, this.projectiles, position, direction);
     });
   }
@@ -644,6 +653,15 @@ export class PlayerControls {
       position: position.toArray(),
       direction: direction.toArray()
     });
+
+    const actions = this.playerModel.userData.actions;
+    const current = this.playerModel.userData.currentAction;
+    const projAction = actions?.projectile;
+    if (projAction) {
+      actions[current]?.fadeOut(0.1);
+      projAction.reset().fadeIn(0.1).play();
+      this.playerModel.userData.currentAction = 'projectile';
+    }
 
     this.spawnProjectile(this.scene, this.projectiles, position, direction);
   }

--- a/projectiles.js
+++ b/projectiles.js
@@ -1,11 +1,16 @@
 import * as THREE from "three";
 import { updateMonster, switchMonsterAnimation } from './characters/MonsterCharacter.js';
+import { getTerrainHeightAt } from "./worldGeneration.js";
 
 export function spawnProjectile(scene, projectiles, position, direction) {
   const geometry = new THREE.SphereGeometry(0.1, 16, 16);
   const material = new THREE.MeshStandardMaterial({ color: 0xff0000 });
   const sphere = new THREE.Mesh(geometry, material);
   sphere.position.copy(position);
+  const groundY = getTerrainHeightAt(position.x, position.z) + 0.1;
+  if (sphere.position.y < groundY) {
+    sphere.position.y = groundY;
+  }
   sphere.userData.velocity = direction.clone().multiplyScalar(0.1);
   sphere.userData.lifetime = 4000;
   sphere.userData.spawnTime = Date.now();
@@ -29,8 +34,9 @@ export function updateProjectiles({
     vel.y += gravity;
     proj.position.add(vel);
 
-    if (proj.position.y <= 0.3) {
-      proj.position.y = 0.3;
+    const terrainY = getTerrainHeightAt(proj.position.x, proj.position.z) + 0.1;
+    if (proj.position.y <= terrainY) {
+      proj.position.y = terrainY;
       vel.y = Math.abs(vel.y) > 0.01 ? vel.y * -0.5 : 0;
     }
     


### PR DESCRIPTION
## Summary
- Play projectile animation when firing from desktop, touch, or voice controls
- Show projectile animation for remote players via multiplayer messages
- Use terrain height for projectiles to spawn and bounce correctly on hills

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e10959dc8832599780fdeae2628f2