### PR TITLE
Sync remote player animations and terrain height

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -72,18 +72,6 @@ export class PlayerControls {
     // Setup event listeners
     this.setupEventListeners();
     
-    // If room is provided, initialize multiplayer presence
-    if (this.multiplayer) {
-      // Initialize player presence in the room
-      this.multiplayer.send({
-        x: this.playerX,
-        y: this.playerY,
-        z: this.playerZ,
-        rotation: 0,
-        moving: false
-      });
-    }
-    
     this.enabled = true; // Add enabled flag for chat input
   }
   


### PR DESCRIPTION
## Summary
- Adjust other players' Y position using local terrain sampling
- Broadcast and apply animation states for remote players
- Remove redundant early presence broadcast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f3bddcfb08325ae713117c0afd991