### PR TITLE
Fix destructible collisions for melee and projectiles

### DIFF
--- a/melee.js
+++ b/melee.js
@@ -54,6 +54,19 @@ export function updateMeleeAttacks({ playerModel, otherPlayers, monster }) {
           }
         }
       }
+
+      if (window.breakManager) {
+        for (const [id, data] of window.breakManager.registry.entries()) {
+          const dist = attacker.model.position.distanceTo(data.object.position);
+          if (dist <= cfg.range) {
+            const dir = new THREE.Vector3()
+              .subVectors(data.object.position, attacker.model.position)
+              .normalize();
+            const impulse = dir.multiplyScalar(2);
+            window.breakManager.onHit(id, cfg.damage, impulse);
+          }
+        }
+      }
       info.hasHit = true;
     }
     if (elapsed > cfg.hitTime + cfg.hitWindow) {

--- a/projectiles.js
+++ b/projectiles.js
@@ -39,7 +39,7 @@ export function updateProjectiles({
       proj.position.y = terrainY;
       vel.y = Math.abs(vel.y) > 0.01 ? vel.y * -0.5 : 0;
     }
-    
+
     const barriers = scene.children.filter(obj => obj.userData?.isBarrier);
 
     for (const barrier of barriers) {
@@ -60,6 +60,9 @@ export function updateProjectiles({
     }
 
     const age = Date.now() - proj.userData.spawnTime;
+
+    let removed = false;
+
     for (const [id, { model }] of Object.entries(otherPlayers)) {
       if (age < 80) continue;
       const projBox = new THREE.Box3().setFromObject(proj);
@@ -72,9 +75,12 @@ export function updateProjectiles({
         }
         scene.remove(proj);
         projectiles.splice(i, 1);
+        removed = true;
         break;
       }
     }
+
+    if (removed) continue;
 
     // Check destructible props loaded via LevelLoader
     if (window.breakManager) {
@@ -85,10 +91,13 @@ export function updateProjectiles({
           window.breakManager.onHit(id, 25, proj.userData.velocity.clone());
           scene.remove(proj);
           projectiles.splice(i, 1);
+          removed = true;
           break;
         }
       }
     }
+
+    if (removed) continue;
 
     const projBox = new THREE.Box3().setFromObject(proj);
     const localBox = new THREE.Box3().setFromObject(playerModel);
@@ -96,6 +105,7 @@ export function updateProjectiles({
       console.log(`💥 You were hit`);
       scene.remove(proj);
       projectiles.splice(i, 1);
+      removed = true;
 
       if (typeof window.localHealth === 'number') {
         window.localHealth = Math.max(0, window.localHealth - 10);
@@ -108,6 +118,8 @@ export function updateProjectiles({
       }
     }
 
+    if (removed) continue;
+
     if (monster) {
       const monsterBox = new THREE.Box3().setFromObject(monster);
       if (projBox.intersectsBox(monsterBox) && age >= 80) {
@@ -115,7 +127,8 @@ export function updateProjectiles({
         monster.userData.mode = "enemy";
         scene.remove(proj);
         projectiles.splice(i, 1);
-        
+        removed = true;
+
         if (typeof window.monsterHealth === 'number') {
           window.monsterHealth = Math.max(0, window.monsterHealth - 10);
           console.log(`👹 Monster Health: ${window.monsterHealth}`);


### PR DESCRIPTION
## Summary
- Allow melee attacks to damage BreakManager objects like buildings
- Remove projectiles once they hit destructibles so BreakManager can process the hit

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f5a3852b08325a950fdbbaa071bda