### PR TITLE
Add health bar and player death handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,6 +89,16 @@ async function main() {
   window.localHealth = 100;
   window.monsterHealth = 100;
 
+  const healthFill = document.getElementById('health-fill');
+  function updateHealthUI() {
+    if (healthFill) {
+      healthFill.style.width = `${window.localHealth}%`;
+    }
+  }
+  updateHealthUI();
+
+  let playerDead = false;
+
   const projectiles = [];
 
   const playerControls = new PlayerControls({
@@ -290,6 +300,20 @@ async function main() {
     requestAnimationFrame(animate);
     playerControls.update();
     updateTerrain();
+
+    updateHealthUI();
+    if (window.localHealth <= 0 && !playerDead) {
+      playerDead = true;
+      playerControls.enabled = false;
+      const actions = playerModel.userData.actions;
+      const current = playerModel.userData.currentAction;
+      const die = actions?.die;
+      if (die) {
+        actions[current]?.fadeOut(0.2);
+        die.reset().fadeIn(0.2).play();
+        playerModel.userData.currentAction = 'die';
+      }
+    }
 
     const delta = mixerClock.getDelta();
     Object.values(otherPlayers).forEach(p => {

--- a/controls.js
+++ b/controls.js
@@ -107,6 +107,7 @@ export class PlayerControls {
     
     // Jump button event listeners
     document.getElementById('jump-button').addEventListener('touchstart', (event) => {
+      if (!this.enabled) return;
       this.jumpButtonPressed = true;
       if (this.canJump) {
         this.velocity.y = JUMP_FORCE;
@@ -114,8 +115,9 @@ export class PlayerControls {
       }
       event.preventDefault();
     });
-    
+
     document.getElementById('jump-button').addEventListener('touchend', (event) => {
+      if (!this.enabled) return;
       this.jumpButtonPressed = false;
       event.preventDefault();
     });
@@ -162,6 +164,7 @@ export class PlayerControls {
 
     // Fire button logic
     document.getElementById('fire-button').addEventListener('touchstart', (event) => {
+      if (!this.enabled) return;
       const position = this.playerModel.position.clone().add(new THREE.Vector3(0, 0.7, 0));
       const direction = new THREE.Vector3(0, 0, 1).applyEuler(this.playerModel.rotation);
 
@@ -182,6 +185,7 @@ export class PlayerControls {
   setupEventListeners() {
     // Listen for key events (for desktop controls)
     document.addEventListener("keydown", (e) => {
+      if (!this.enabled) return;
       const key = e.key.toLowerCase();
       this.keysPressed.add(key);
 
@@ -616,6 +620,7 @@ export class PlayerControls {
    * Useful for alternative input methods like voice commands.
    */
   triggerJump() {
+    if (!this.enabled) return;
     if (this.canJump) {
       this.velocity.y = JUMP_FORCE;
       this.canJump = false;
@@ -627,6 +632,7 @@ export class PlayerControls {
    * Useful for alternative input methods like voice commands.
    */
   triggerFire() {
+    if (!this.enabled) return;
     const position = this.playerModel.position.clone().add(new THREE.Vector3(0, 0.7, 0));
     const direction = new THREE.Vector3(0, 0, 1).applyEuler(this.playerModel.rotation);
 

--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
   <div id="game-container">
     <div class="crosshair"></div>
   </div>
+  <div id="health-bar"><div id="health-fill"></div></div>
   <button id="voice-button" style="position: absolute; bottom: 20px; left: 20px; z-index: 10;">
     Unmute
-  </button>  
+  </button>
   
   <!-- Settings Button -->
   <div id="settings-button">⚙️</div>

--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -43,7 +43,8 @@ export function createPlayerModel(THREE, username, onLoad) {
         mutantPunch: 'Mutant Punch.fbx',
         mmaKick: 'Mma Kick.fbx',
         hurricaneKick: 'Hurricane Kick.fbx',
-        projectile: 'Projectile.fbx'
+        projectile: 'Projectile.fbx',
+        die: 'Dying.fbx'
       };
 
       const promises = Object.entries(animationFiles).map(([name, file]) => {
@@ -53,7 +54,7 @@ export function createPlayerModel(THREE, username, onLoad) {
             (anim) => {
               const clip = anim.animations[0];
               const action = mixer.clipAction(clip);
-              if (['jump', 'hit', 'mutantPunch', 'mmaKick', 'hurricaneKick', 'projectile'].includes(name)) {
+              if (['jump', 'hit', 'mutantPunch', 'mmaKick', 'hurricaneKick', 'projectile', 'die'].includes(name)) {
                 action.loop = THREE.LoopOnce;
                 action.clampWhenFinished = true;
               }

--- a/styles.css
+++ b/styles.css
@@ -198,6 +198,23 @@ body {
   cursor: pointer;
 }
 
+#health-bar {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 150px;
+  height: 20px;
+  background: #555;
+  border: 2px solid #000;
+  z-index: 1000;
+}
+
+#health-fill {
+  height: 100%;
+  background: #0f0;
+  width: 100%;
+}
+
 #voice-button {
   position: fixed;
   bottom: 50px;


### PR DESCRIPTION
## Summary
- Add top-left health bar for local player and update with current health
- Play Dying animation and freeze controls when health reaches zero
- Load Dying animation asset and respect control disabling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f5d08df4883258d350423850c314e