### PR TITLE
Enable movement during projectile and add sliding run kick

### DIFF
--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -42,6 +42,7 @@ export function createPlayerModel(THREE, username, onLoad) {
         hit: 'Flying Back Death.fbx',
         mutantPunch: 'Mutant Punch.fbx',
         mmaKick: 'Mma Kick.fbx',
+        runningKick: 'Female Laying Pose.fbx',
         hurricaneKick: 'Hurricane Kick.fbx',
         projectile: 'Projectile.fbx',
         die: 'Dying.fbx'
@@ -54,7 +55,7 @@ export function createPlayerModel(THREE, username, onLoad) {
             (anim) => {
               const clip = anim.animations[0];
               const action = mixer.clipAction(clip);
-              if (['jump', 'hit', 'mutantPunch', 'mmaKick', 'hurricaneKick', 'projectile', 'die'].includes(name)) {
+              if (['jump', 'hit', 'mutantPunch', 'mmaKick', 'runningKick', 'hurricaneKick', 'projectile', 'die'].includes(name)) {
                 action.loop = THREE.LoopOnce;
                 action.clampWhenFinished = true;
               }


### PR DESCRIPTION
## Summary
- Keep movement controls active while firing projectiles
- Add slide momentum when punching or kicking while running
- Use "Female Laying Pose.fbx" for run kicks and load the animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f8c7079c88325ae7b65de371e0bdb