### PR TITLE
Add landscape mobile control layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -350,17 +350,39 @@ body {
 }
 
 
-@media (max-width: 768px) {
+@media (pointer: coarse) and (max-width: 768px),
+       (pointer: coarse) and (max-height: 768px) {
   #joystick-container {
     display: block;
   }
-  
+
   #jump-button {
     display: block;
   }
-  
+
   .instructions {
     display: none !important;
+  }
+}
+
+@media (pointer: coarse) and (orientation: landscape) {
+  #joystick-container {
+    left: 20px;
+    right: auto;
+    bottom: 20px;
+  }
+
+  #jump-button {
+    left: auto;
+    right: 20px;
+    bottom: 20px;
+  }
+
+  #action-buttons {
+    left: auto;
+    right: 120px;
+    bottom: 20px;
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## Summary
- Show mobile joystick and jump controls on touch devices in landscape mode
- Reposition mobile controls for landscape orientation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0b41410408325868750e83b23ee85