### PR TITLE
Add push-to-talk speech recognition button

### DIFF
--- a/app.js
+++ b/app.js
@@ -201,7 +201,29 @@ async function main() {
     fire: () => playerControls.triggerFire(),
     shoot: () => playerControls.triggerFire()
   });
-  speech.start();
+  const talkButton = document.getElementById('talk-button');
+  if (talkButton) {
+    let talking = false;
+    const startTalking = (e) => {
+      e.preventDefault();
+      if (!talking) {
+        talking = true;
+        speech.start();
+      }
+    };
+    const stopTalking = (e) => {
+      if (talking) {
+        if (e) e.preventDefault();
+        talking = false;
+        speech.stop();
+      }
+    };
+    talkButton.addEventListener('mousedown', startTalking);
+    talkButton.addEventListener('touchstart', startTalking);
+    window.addEventListener('mouseup', stopTalking);
+    window.addEventListener('touchend', stopTalking);
+    window.addEventListener('touchcancel', stopTalking);
+  }
 
   const generatedChunks = new Set();
   const chunkSize = 50;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <div id="health-bar"><div id="health-fill"></div></div>
   <div id="action-buttons">
     <button id="voice-button" class="action-button">Unmute</button>
+    <button id="talk-button" class="action-button">🎤</button>
   </div>
   
   <!-- Settings Button -->


### PR DESCRIPTION
## Summary
- Add microphone button to action bar for push-to-talk speech recognition
- Integrate button with existing speech commands to start/stop recognition while held

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a0b7688d68832599a0b64b987a8dea