### PR TITLE
Add level builder transform arrows and fix pivot

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
   </div>
 
   <div id="level-builder-sidebar" class="hidden"></div>
+  <div id="level-builder-controls" class="hidden">
+    <button data-mode="translate">⇄</button>
+    <button data-mode="rotate">⟳</button>
+    <button data-mode="scale">⤢</button>
+  </div>
 
   <script src="app.js" type="module"></script>
 </body>


### PR DESCRIPTION
## Summary
- expose Move/Rotate/Scale arrows in `index.html` for level builder
- center spawned props so rotation/scale happens around their middle
- hook up external controls and import TransformControls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0f6ce24c08325a5c711a82f898edb