### PR TITLE
Add character selector to settings

### DIFF
--- a/characters/PlayerCharacter.js
+++ b/characters/PlayerCharacter.js
@@ -4,14 +4,15 @@ import { createPlayerModel } from "../models/playerModel.js";
 import * as THREE from "three";
 
 export class PlayerCharacter extends CharacterBase {
-  constructor(username) {
+  constructor(username, modelPath) {
     const { model, nameLabel } = createPlayerModel(
       THREE,
       username,
       ({ mixer, actions }) => {
         this.mixer = mixer;
         this.actions = actions;
-      }
+      },
+      modelPath
     );
     super(model);
     this.nameLabel = nameLabel;

--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
     <div id="settings-panel">
       <label for="name-input">Name:</label>
       <input type="text" id="name-input" />
+      <label for="character-select">Character:</label>
+      <select id="character-select"></select>
       <button id="save-settings">Save</button>
 
       <button id="toggle-console">Show Console</button>

--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -1,12 +1,17 @@
 // /models/playerModel.js
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
 
-export function createPlayerModel(THREE, username, onLoad) {
+export function createPlayerModel(
+  THREE,
+  username,
+  onLoad,
+  modelPath = '/models/old_man/model.fbx'
+) {
   const playerGroup = new THREE.Group();
   const loader = new FBXLoader();
 
   loader.load(
-    '/models/old_man/model.fbx',
+    modelPath,
     (fbx) => {
       const model = fbx;
 

--- a/styles.css
+++ b/styles.css
@@ -319,7 +319,8 @@ body {
   text-align: center;
 }
 
-#settings-panel input {
+#settings-panel input,
+#settings-panel select {
   margin-top: 8px;
   margin-bottom: 12px;
   padding: 4px;


### PR DESCRIPTION
## Summary
- Enable choosing a player model from available `/models/*` directories
- Store selected character in cookies and load it on startup
- Style and expose character selector in settings panel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ec185e083258b087cfb15cb1a16