### PR TITLE
Use Rapier blocks for projectiles

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,6 +97,8 @@ async function main() {
   // --- RAPIER INIT ---
   await RAPIER.init();
   rapierWorld = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
+  window.rapierWorld = rapierWorld;
+  window.rbToMesh = rbToMesh;
   breakManager.setWorld(rapierWorld);
 
   // Huge static ground so the blocks land (visual terrain stays as-is)


### PR DESCRIPTION
## Summary
- Spawn projectiles as small, random-colored cubes with Rapier rigid bodies
- Sync projectile motion via Rapier and remove manually simulated physics
- Expose Rapier world and rigid body map globally for projectile access

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: [vite]: Rollup failed to resolve import "@dimforge/rapier3d-compat")*


------
https://chatgpt.com/codex/tasks/task_e_68af46614e708325bba831d55e26accc