### PR TITLE
Clean up Rapier bodies when projectiles are removed

### DIFF
--- a/breakManager.js
+++ b/breakManager.js
@@ -34,7 +34,7 @@ export class BreakManager {
   }
 
   // Apply damage to an object. Once health <= 0 the object is replaced with its chunks.
-  async onHit(id, damage = 10, impulse = new THREE.Vector3()) {
+  onHit(id, damage = 10, impulse = new THREE.Vector3()) {
     const entry = this.registry.get(id);
     if (!entry || !this.world) return;
     entry.health -= damage;

--- a/projectiles.js
+++ b/projectiles.js
@@ -45,6 +45,15 @@ export function updateProjectiles({
   monster,
   clock
 }) {
+  const removeProjectile = (index) => {
+    const p = projectiles[index];
+    const body = p.userData.rb;
+    scene.remove(p);
+    projectiles.splice(index, 1);
+    window.rbToMesh.delete(body);
+    window.rapierWorld.removeRigidBody(body);
+  };
+
   for (let i = projectiles.length - 1; i >= 0; i--) {
     const proj = projectiles[i];
     const rb = proj.userData.rb;
@@ -54,10 +63,7 @@ export function updateProjectiles({
 
     proj.userData.lifetime -= 16;
     if (proj.userData.lifetime <= 0) {
-      scene.remove(proj);
-      projectiles.splice(i, 1);
-      window.rbToMesh.delete(rb);
-      window.rapierWorld.removeRigidBody(rb);
+      removeProjectile(i);
       continue;
     }
 
@@ -75,8 +81,7 @@ export function updateProjectiles({
           player.health = Math.max(0, (player.health || 100) - 10);
           console.log(`💥 Hit player: ${id}, Health: ${player.health}`);
         }
-        scene.remove(proj);
-        projectiles.splice(i, 1);
+        removeProjectile(i);
         removed = true;
         break;
       }
@@ -92,8 +97,7 @@ export function updateProjectiles({
           window.breakManager.onHit(id, 25, proj.userData.velocity.clone());
           const remaining = window.breakManager.registry.get(id)?.health ?? 0;
           console.log(`🎯 ${id} health: ${remaining}`);
-          scene.remove(proj);
-          projectiles.splice(i, 1);
+          removeProjectile(i);
           removed = true;
           break;
         }
@@ -106,8 +110,7 @@ export function updateProjectiles({
     const localBox = new THREE.Box3().setFromObject(playerModel);
     if (projBox.intersectsBox(localBox) && age >= 80) {
       console.log(`💥 You were hit`);
-      scene.remove(proj);
-      projectiles.splice(i, 1);
+      removeProjectile(i);
       removed = true;
 
       if (typeof window.localHealth === 'number') {
@@ -128,8 +131,7 @@ export function updateProjectiles({
       if (projBox.intersectsBox(monsterBox) && age >= 80) {
         console.log(`💥 Monster was hit`);
         monster.userData.mode = "enemy";
-        scene.remove(proj);
-        projectiles.splice(i, 1);
+        removeProjectile(i);
         removed = true;
 
         if (typeof window.monsterHealth === 'number') {


### PR DESCRIPTION
## Summary
- ensure projectiles always remove their Rapier rigid bodies and bookkeeping when destroyed
- simplify BreakManager.onHit to synchronous function

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af490a2930832597415ddb2f2b15b9