### PR TITLE
Add spherical terrain with radial gravity

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { loadMonsterModel } from "./models/monsterModel.js";
 import { createOrcVoice } from "./orcVoice.js";
-import { createClouds, generateTerrainChunk, getTerrainHeightAt } from "./worldGeneration.js";
+import { createClouds, createTerrainSphere, SPHERE_RADIUS } from "./worldGeneration.js";
 import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
@@ -54,6 +54,8 @@ async function main() {
   let monster = null;
   loadMonsterModel(scene, data => {
     monster = data.model;
+    monster.position.set(0, SPHERE_RADIUS + 1, 0);
+    monster.up.copy(monster.position.clone().normalize());
     // Expose monster globally for interactions like grabbing
     window.monster = monster;
     monster.userData.mixer = data.mixer;
@@ -99,28 +101,11 @@ async function main() {
 
   // --- RAPIER INIT ---
   await RAPIER.init();
-  rapierWorld = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
+  rapierWorld = new RAPIER.World({ x: 0, y: 0, z: 0 });
   window.rapierWorld = rapierWorld;
   window.rbToMesh = rbToMesh;
   breakManager.setWorld(rapierWorld);
-
-  // Huge static ground so the blocks land (visual terrain stays as-is)
-  {
-    const groundRb = rapierWorld.createRigidBody(RAPIER.RigidBodyDesc.fixed().setTranslation(0, -1, 0));
-    rapierWorld.createCollider(
-      RAPIER.ColliderDesc.cuboid(200, 1, 200), // half-extents
-      groundRb
-    );
-
-    // Optional: faint ground helper (invisible if you prefer)
-    const ground = new THREE.Mesh(
-      new THREE.PlaneGeometry(400, 400),
-      new THREE.MeshStandardMaterial({ color: 0x556b2f, metalness: 0, roughness: 1, transparent: true, opacity: 0.12 })
-    );
-    ground.rotation.x = -Math.PI / 2;
-    ground.position.y = -0.99;
-    scene.add(ground);
-  }
+  createTerrainSphere(scene, SPHERE_RADIUS);
 
   function attachMonsterPhysics(mon) {
     const rbDesc = RAPIER.RigidBodyDesc.dynamic()
@@ -143,6 +128,7 @@ async function main() {
   scene.add(playerModel);
   document.body.appendChild(player.nameLabel);
   window.playerModel = playerModel;
+  playerModel.up.copy(playerModel.position.clone().normalize());
   audioManager.playBGS('Forest Day/Forest Day.ogg');
 
   window.localHealth = 100;
@@ -320,10 +306,14 @@ async function main() {
   function respawnPlayer() {
     window.localHealth = 100;
     updateHealthUI();
-    const newX = (Math.random() * 10) - 5;
-    const newZ = (Math.random() * 10) - 5;
-    const newY = getTerrainHeightAt(newX, newZ) + 0.5;
+    const theta = Math.random() * Math.PI * 2;
+    const phi = Math.acos(2 * Math.random() - 1);
+    const r = SPHERE_RADIUS + 0.5;
+    const newX = r * Math.sin(phi) * Math.cos(theta);
+    const newY = r * Math.cos(phi);
+    const newZ = r * Math.sin(phi) * Math.sin(theta);
     playerModel.position.set(newX, newY, newZ);
+    playerModel.up.copy(playerModel.position.clone().normalize());
     playerControls.playerX = newX;
     playerControls.playerY = newY;
     playerControls.playerZ = newZ;
@@ -368,25 +358,6 @@ async function main() {
     window.addEventListener('touchcancel', stopTalking);
   }
 
-  const generatedChunks = new Set();
-  const chunkSize = 50;
-
-  function updateTerrain() {
-    const playerPos = playerModel.position;
-    const cx = Math.floor(playerPos.x / chunkSize);
-    const cz = Math.floor(playerPos.z / chunkSize);
-
-    for (let dx = -1; dx <= 1; dx++) {
-      for (let dz = -1; dz <= 1; dz++) {
-        const key = `${cx + dx},${cz + dz}`;
-        if (!generatedChunks.has(key)) {
-          generateTerrainChunk(scene, cx + dx, cz + dz, chunkSize);
-          generatedChunks.add(key);
-        }
-      }
-    }
-  }
-
   const otherPlayers = {};
   // Expose remote players map for global access (e.g., controls)
   window.otherPlayers = otherPlayers;
@@ -404,22 +375,8 @@ async function main() {
       const player = otherPlayers[data.id];
       player.name = data.name;
       // Update remote player position and rotation
-      player.model.position.x = data.x;
-      player.model.position.z = data.z;
-
-      // Ensure terrain chunk exists locally for remote player position
-      const rcx = Math.floor(data.x / chunkSize);
-      const rcz = Math.floor(data.z / chunkSize);
-      const rkey = `${rcx},${rcz}`;
-      if (!generatedChunks.has(rkey)) {
-        generateTerrainChunk(scene, rcx, rcz, chunkSize);
-        generatedChunks.add(rkey);
-      }
-
-      // Adjust vertical placement against local terrain height
-      const terrainY = getTerrainHeightAt(data.x, data.z);
-      const targetY = Math.max(data.y ?? terrainY, terrainY);
-      player.model.position.y = targetY;
+      player.model.position.set(data.x, data.y, data.z);
+      player.model.up.copy(player.model.position.clone().normalize());
       player.model.rotation.y = data.rotation;
 
       // Sync animation state if provided
@@ -592,6 +549,19 @@ async function main() {
     // Accumulate variable rAF time into fixed physics steps
     physicsAccumulator += clock.getDelta();
     while (physicsAccumulator >= FIXED_DT) {
+      rapierWorld.bodies.forEach((body) => {
+        if (!body.isDynamic()) return;
+        const t = body.translation();
+        const dir = { x: -t.x, y: -t.y, z: -t.z };
+        const len = Math.hypot(dir.x, dir.y, dir.z) || 1;
+        const mass = body.mass();
+        const g = 9.81;
+        body.addForce({
+          x: (dir.x / len) * g * mass,
+          y: (dir.y / len) * g * mass,
+          z: (dir.z / len) * g * mass,
+        }, true);
+      });
       rapierWorld.step();
       physicsAccumulator -= FIXED_DT;
     }
@@ -617,7 +587,6 @@ async function main() {
 
 
     playerControls.update();
-    updateTerrain();
 
     updateHealthUI();
     if (window.localHealth <= 0 && !playerDead) {

--- a/controls.js
+++ b/controls.js
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { getTerrainHeightAt } from "./worldGeneration.js";
+import { SPHERE_RADIUS } from "./worldGeneration.js";
 import RAPIER from "@dimforge/rapier3d-compat";
 
 // Movement constants
@@ -53,11 +53,10 @@ export class PlayerControls {
     this.moveForward = 0;
     this.moveRight = 0;
     
-    // Initial player position
-    // const initialPos = { x: 0, y: 0.5, z: 0 };
-    this.playerX = (Math.random() * 10) - 5;
-    this.playerZ = (Math.random() * 10) - 5;
-    this.playerY = getTerrainHeightAt(this.playerX, this.playerZ) + 0.5;
+    // Initial player position on the sphere surface
+    this.playerX = 0;
+    this.playerZ = 0;
+    this.playerY = SPHERE_RADIUS + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
 
     
     // Set initial player model position if it exists
@@ -82,7 +81,8 @@ export class PlayerControls {
     this.camera.lookAt(this.playerX, this.playerY + 1, this.playerZ);
     // Store the initial camera offset (relative to player's target position)
     this.cameraOffset = new THREE.Vector3();
-    this.cameraOffset.copy(this.camera.position).sub(new THREE.Vector3(this.playerX, this.playerY + 1, this.playerZ));
+    const initialUp = new THREE.Vector3(this.playerX, this.playerY, this.playerZ).normalize();
+    this.cameraOffset.copy(this.camera.position).sub(new THREE.Vector3(this.playerX, this.playerY, this.playerZ).add(initialUp));
 
     // Initialize controls based on device
     this.initializeControls();
@@ -124,7 +124,9 @@ export class PlayerControls {
       if (!this.enabled) return;
       this.jumpButtonPressed = true;
       if (this.canJump && this.body) {
-        this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+        const t = this.body.translation();
+        const up = new THREE.Vector3(t.x, t.y, t.z).normalize();
+        this.body.applyImpulse({ x: up.x * JUMP_FORCE, y: up.y * JUMP_FORCE, z: up.z * JUMP_FORCE }, true);
         this.canJump = false;
       }
       event.preventDefault();
@@ -271,11 +273,15 @@ export class PlayerControls {
 
       if (e.key === " ") {
         if (this.canJump && this.body) {
-          this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+          const t = this.body.translation();
+          const up = new THREE.Vector3(t.x, t.y, t.z).normalize();
+          this.body.applyImpulse({ x: up.x * JUMP_FORCE, y: up.y * JUMP_FORCE, z: up.z * JUMP_FORCE }, true);
           this.canJump = false;
           this.hasDoubleJumped = false;
         } else if (!this.hasDoubleJumped && this.body) {
-          this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+          const t = this.body.translation();
+          const up = new THREE.Vector3(t.x, t.y, t.z).normalize();
+          this.body.applyImpulse({ x: up.x * JUMP_FORCE, y: up.y * JUMP_FORCE, z: up.z * JUMP_FORCE }, true);
           this.hasDoubleJumped = true;
           this.playAction('hurricaneKick');
         }
@@ -426,9 +432,12 @@ export class PlayerControls {
       return;
     }
 
-    const terrainY = getTerrainHeightAt(t.x, t.z);
-    const expectedY = terrainY + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
-    if (t.y <= expectedY + 0.05 && Math.abs(vel.y) < 0.1) {
+    const pos = new THREE.Vector3(t.x, t.y, t.z);
+    const up = pos.clone().normalize();
+    const velVec = new THREE.Vector3(vel.x, vel.y, vel.z);
+    const radialVel = up.clone().multiplyScalar(velVec.dot(up));
+    const surfaceDist = SPHERE_RADIUS + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
+    if (Math.abs(pos.length() - surfaceDist) < 0.05 && radialVel.length() < 0.1) {
       this.canJump = true;
       this.hasDoubleJumped = false;
     }
@@ -439,9 +448,8 @@ export class PlayerControls {
         if (this.joystickForce > 0.1) {
           const cameraForward = new THREE.Vector3();
           this.camera.getWorldDirection(cameraForward);
-          cameraForward.y = 0;
-          cameraForward.normalize();
-          const cameraRight = new THREE.Vector3().crossVectors(cameraForward, new THREE.Vector3(0, 1, 0)).normalize();
+          cameraForward.projectOnPlane(up).normalize();
+          const cameraRight = new THREE.Vector3().crossVectors(cameraForward, up).normalize();
           const dx = Math.cos(this.joystickAngle);
           const dz = Math.sin(this.joystickAngle);
           moveDirection.addScaledVector(cameraForward, dz * this.joystickForce);
@@ -457,10 +465,8 @@ export class PlayerControls {
     if (!this.isMobile && moveDirection.length() > 0) moveDirection.normalize();
     const cameraDirection = new THREE.Vector3();
     this.camera.getWorldDirection(cameraDirection);
-    cameraDirection.y = 0;
-    cameraDirection.normalize();
-    const rightVector = new THREE.Vector3();
-    rightVector.crossVectors(this.camera.up, cameraDirection).normalize();
+    cameraDirection.projectOnPlane(up).normalize();
+    const rightVector = new THREE.Vector3().crossVectors(cameraDirection, up).normalize();
     const movement = new THREE.Vector3();
     if (!this.isMobile) {
       if (moveDirection.z !== 0) movement.add(cameraDirection.clone().multiplyScalar(moveDirection.z));
@@ -486,7 +492,8 @@ export class PlayerControls {
         this.playerModel.userData.currentAction = 'idle';
       }
     } else {
-      this.body.setLinvel({ x: movement.x * SPEED, y: vel.y, z: movement.z * SPEED }, true);
+      const newVel = radialVel.add(movement.clone().multiplyScalar(SPEED));
+      this.body.setLinvel({ x: newVel.x, y: newVel.y, z: newVel.z }, true);
     }
     const newX = t.x;
     const newY = t.y;
@@ -498,9 +505,10 @@ export class PlayerControls {
     }
     if (this.playerModel) {
       this.playerModel.position.set(newX, newY, newZ);
+      this.playerModel.up.copy(up);
       if (movement.length() > 0) {
-        const angle = Math.atan2(movement.x, movement.z);
-        this.playerModel.rotation.y = angle;
+        const target = this.playerModel.position.clone().add(movement);
+        this.playerModel.lookAt(target);
       }
       const actions = this.playerModel.userData.actions;
       if (actions && !this.isKnocked && !this.currentSpecialAction) {
@@ -514,7 +522,7 @@ export class PlayerControls {
           this.playerModel.userData.currentAction = actionName;
         }
       }
-      const newTarget = new THREE.Vector3(this.playerModel.position.x, this.playerModel.position.y + 1, this.playerModel.position.z);
+      const newTarget = this.playerModel.position.clone().add(up);
       if (this.controls) {
         this.controls.target.copy(newTarget);
       }
@@ -555,14 +563,16 @@ export class PlayerControls {
       this.pitch = Math.max(minPitch, this.pitch - 0.02);
     }
 
-    const orbitCenter = this.playerModel.position.clone().add(new THREE.Vector3(0, 1, 0));
+    const up = this.playerModel.position.clone().normalize();
+    const orbitCenter = this.playerModel.position.clone().add(up);
     const rotatedOffset = new THREE.Vector3(
       this.cameraOffset.x * Math.cos(this.yaw) - this.cameraOffset.z * Math.sin(this.yaw),
       this.cameraOffset.y + 5 * Math.sin(this.pitch),
       this.cameraOffset.x * Math.sin(this.yaw) + this.cameraOffset.z * Math.cos(this.yaw)
-    );
+    ).applyQuaternion(new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), up));
 
     this.camera.position.copy(orbitCenter).add(rotatedOffset);
+    this.camera.up.copy(up);
     this.camera.lookAt(orbitCenter);
 
       const now = performance.now();
@@ -603,7 +613,9 @@ export class PlayerControls {
   triggerJump() {
     if (!this.enabled || !this.body) return;
     if (this.canJump) {
-      this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+      const t = this.body.translation();
+      const up = new THREE.Vector3(t.x, t.y, t.z).normalize();
+      this.body.applyImpulse({ x: up.x * JUMP_FORCE, y: up.y * JUMP_FORCE, z: up.z * JUMP_FORCE }, true);
       this.canJump = false;
     }
   }

--- a/projectiles.js
+++ b/projectiles.js
@@ -1,7 +1,6 @@
 import * as THREE from "three";
 import RAPIER from '@dimforge/rapier3d-compat';
 import { updateMonster, switchMonsterAnimation } from './characters/MonsterCharacter.js';
-import { getTerrainHeightAt } from "./worldGeneration.js";
 
 export function spawnProjectile(scene, projectiles, position, direction) {
   const size = 0.1;
@@ -11,10 +10,6 @@ export function spawnProjectile(scene, projectiles, position, direction) {
   const material = new THREE.MeshStandardMaterial({ color });
   const box = new THREE.Mesh(geometry, material);
   box.position.copy(position.clone().add(direction.clone().normalize().multiplyScalar(1.2)));
-  const groundY = getTerrainHeightAt(position.x, position.z) + half;
-  if (box.position.y < groundY) {
-    box.position.y = groundY;
-  }
 
   // Rapier body
   const world = window.rapierWorld;


### PR DESCRIPTION
## Summary
- Replace planar terrain generation with a small spherical world
- Apply radial gravity and update player controls to walk around the sphere
- Simplify projectile spawn and respawn logic for spherical environment

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b071d5ea70832597e26a4164fa23b2