### PR TITLE
Reduce player bounce near spaceship

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -75,7 +75,10 @@ export class PlayerControls {
         .setLinearDamping(0.9)
         .setAngularDamping(0.9);
       this.body = world.createRigidBody(rbDesc);
-      const colDesc = RAPIER.ColliderDesc.capsule(PLAYER_HALF_HEIGHT, PLAYER_RADIUS);
+      const colDesc = RAPIER.ColliderDesc
+        .capsule(PLAYER_HALF_HEIGHT, PLAYER_RADIUS)
+        .setRestitution(0)
+        .setFriction(1);
       world.createCollider(colDesc, this.body);
     }
 

--- a/spaceship.js
+++ b/spaceship.js
@@ -45,7 +45,9 @@ export class Spaceship {
 
     const offset = new THREE.Vector3().subVectors(center, ship.position);
     const colDesc = RAPIER.ColliderDesc.cuboid(size.x * 0.5, size.y * 0.5, size.z * 0.5)
-      .setTranslation(offset.x, offset.y, offset.z);
+      .setTranslation(offset.x, offset.y, offset.z)
+      .setRestitution(0)
+      .setFriction(1);
     this.world.createCollider(colDesc, this.body);
 
     // Register with global rigid-body map so physics sync updates the mesh


### PR DESCRIPTION
## Summary
- Set player collider restitution to 0 and friction to 1
- Set spaceship collider restitution to 0 and friction to 1

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1cccda3808325a7aaa64321fe78ff