### PR TITLE
Prevent objects from sinking below terrain

### DIFF
--- a/app.js
+++ b/app.js
@@ -622,6 +622,21 @@ async function main() {
       mesh.position.set(t.x, t.y, t.z);
       mesh.quaternion.set(r.x, r.y, r.z, r.w);
 
+      if (!mesh.userData?.isTerrain) {
+        mesh.updateMatrixWorld();
+        const bbox = new THREE.Box3().setFromObject(mesh);
+        const terrainY = getTerrainHeightAt(mesh.position.x, mesh.position.z);
+        if (bbox.min.y < terrainY) {
+          const correction = terrainY - bbox.min.y;
+          mesh.position.y += correction;
+          rb.setTranslation({ x: mesh.position.x, y: mesh.position.y, z: mesh.position.z }, true);
+          const lv = rb.linvel();
+          if (lv.y < 0) {
+            rb.setLinvel({ x: lv.x, y: 0, z: lv.z }, true);
+          }
+        }
+      }
+
       // Simple cleanup: remove if it falls far below the world
       if (mesh.position.y < -50) {
         scene.remove(mesh);

--- a/controls.js
+++ b/controls.js
@@ -489,6 +489,13 @@ export class PlayerControls {
       this.canJump = true;
       this.hasDoubleJumped = false;
     }
+    if (t.y < expectedY) {
+      this.body.setTranslation({ x: t.x, y: expectedY, z: t.z }, true);
+      if (vel.y < 0) {
+        this.body.setLinvel({ x: vel.x, y: 0, z: vel.z }, true);
+      }
+      t.y = expectedY;
+    }
     const moveDirection = new THREE.Vector3(0, 0, 0);
     const movementLocked = ['mutantPunch', 'mmaKick', 'runningKick'].includes(this.currentSpecialAction);
     if (!movementLocked) {


### PR DESCRIPTION
## Summary
- Clamp player rigidbody above terrain and cancel downward velocity
- Ensure all physics objects stay above terrain during animation loop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b1d4f287d8832594e5cf68457f799d