### PR TITLE
Zoom camera out when mounted on spaceship

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -630,11 +630,24 @@ export class PlayerControls {
       this.pitch = Math.max(minPitch, this.pitch - 0.02);
     }
 
-    const orbitCenter = this.playerModel.position.clone().add(new THREE.Vector3(0, 1, 0));
+    let orbitCenter;
+    let offset;
+    if (this.vehicle && this.vehicle.mesh) {
+      const size = this.vehicle.boundingSize;
+      const centerOffset = this.vehicle.boundingCenterOffset || new THREE.Vector3();
+      orbitCenter = this.vehicle.mesh.position.clone().add(centerOffset);
+      const maxDim = Math.max(size.x, size.y, size.z);
+      const fov = THREE.MathUtils.degToRad(this.camera.fov);
+      const distance = (maxDim * 0.5) / Math.tan(fov / 2) + maxDim * 0.5;
+      offset = new THREE.Vector3(0, maxDim * 0.5, distance);
+    } else {
+      orbitCenter = this.playerModel.position.clone().add(new THREE.Vector3(0, 1, 0));
+      offset = this.cameraOffset;
+    }
     const rotatedOffset = new THREE.Vector3(
-      this.cameraOffset.x * Math.cos(this.yaw) - this.cameraOffset.z * Math.sin(this.yaw),
-      this.cameraOffset.y + 5 * Math.sin(this.pitch),
-      this.cameraOffset.x * Math.sin(this.yaw) + this.cameraOffset.z * Math.cos(this.yaw)
+      offset.x * Math.cos(this.yaw) - offset.z * Math.sin(this.yaw),
+      offset.y + 5 * Math.sin(this.pitch),
+      offset.x * Math.sin(this.yaw) + offset.z * Math.cos(this.yaw)
     );
 
     this.camera.position.copy(orbitCenter).add(rotatedOffset);

--- a/spaceship.js
+++ b/spaceship.js
@@ -35,6 +35,10 @@ export class Spaceship {
     bbox.getSize(size);
     bbox.getCenter(center);
 
+    // Store size and center offset for camera calculations
+    this.boundingSize = size.clone();
+    this.boundingCenterOffset = new THREE.Vector3().subVectors(center, ship.position);
+
     // Create physics body centered on mesh
     const rbDesc = RAPIER.RigidBodyDesc.dynamic()
       .setTranslation(ship.position.x, ship.position.y, ship.position.z)


### PR DESCRIPTION
## Summary
- store spaceship bounding size and center offset for later calculations
- adjust player camera to center and zoom out on mounted spaceship so entire craft is visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b2013893608325afdf72432d076c67