### PR TITLE
Fix terrain chunk indexing

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { loadMonsterModel } from "./models/monsterModel.js";
 import { createOrcVoice } from "./orcVoice.js";
-import { createClouds, generateTerrainChunk, getTerrainHeightAt } from "./worldGeneration.js";
+import { createClouds, generateTerrainChunk, getTerrainHeightAt, chunkIndex } from "./worldGeneration.js";
 import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
@@ -337,8 +337,8 @@ async function main() {
     updateHealthUI();
     const newX = (Math.random() * 10) - 5;
     const newZ = (Math.random() * 10) - 5;
-    const cx = Math.floor(newX / chunkSize);
-    const cz = Math.floor(newZ / chunkSize);
+    const cx = chunkIndex(newX, chunkSize);
+    const cz = chunkIndex(newZ, chunkSize);
     const key = `${cx},${cz}`;
     if (!generatedChunks.has(key)) {
       generateTerrainChunk(scene, cx, cz, chunkSize);
@@ -392,8 +392,8 @@ async function main() {
 
   function updateTerrain() {
     const playerPos = playerModel.position;
-    const cx = Math.floor(playerPos.x / chunkSize);
-    const cz = Math.floor(playerPos.z / chunkSize);
+    const cx = chunkIndex(playerPos.x, chunkSize);
+    const cz = chunkIndex(playerPos.z, chunkSize);
 
     for (let dx = -1; dx <= 1; dx++) {
       for (let dz = -1; dz <= 1; dz++) {
@@ -427,8 +427,8 @@ async function main() {
       player.model.position.z = data.z;
 
       // Ensure terrain chunk exists locally for remote player position
-      const rcx = Math.floor(data.x / chunkSize);
-      const rcz = Math.floor(data.z / chunkSize);
+      const rcx = chunkIndex(data.x, chunkSize);
+      const rcz = chunkIndex(data.z, chunkSize);
       const rkey = `${rcx},${rcz}`;
       if (!generatedChunks.has(rkey)) {
         generateTerrainChunk(scene, rcx, rcz, chunkSize);

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -39,10 +39,16 @@ export function createClouds(scene) {
 
 export const terrainChunks = new Map();
 
+export const baseHeightFunction = (x, z) => {
+  return Math.sin(x * 0.1) * Math.cos(z * 0.1) * 2;
+};
+
+export function chunkIndex(value, size = 50) {
+  return Math.floor((value + size / 2) / size);
+}
+
 export function generateTerrainChunk(scene, chunkX, chunkZ, size = 50) {
-  const heightFunction = (x, z) => {
-    return Math.sin(x * 0.1) * Math.cos(z * 0.1) * 2;
-  };
+  const heightFunction = baseHeightFunction;
 
   const geometry = new THREE.PlaneGeometry(size, size, 32, 32);
   geometry.rotateX(-Math.PI / 2);
@@ -80,10 +86,8 @@ export function generateTerrainChunk(scene, chunkX, chunkZ, size = 50) {
 
 export function getTerrainHeightAt(x, z) {
   const chunkSize = 50;
-  const cx = Math.floor(x / chunkSize);
-  const cz = Math.floor(z / chunkSize);
-  const key = `${cx},${cz}`;
+  const key = `${chunkIndex(x, chunkSize)},${chunkIndex(z, chunkSize)}`;
   const chunk = terrainChunks.get(key);
-  if (!chunk) return 0;
-  return chunk.heightFunction(x, z);
+  const heightFn = chunk ? chunk.heightFunction : baseHeightFunction;
+  return heightFn(x, z);
 }


### PR DESCRIPTION
## Summary
- correct terrain chunk lookup with `chunkIndex`
- compute height even when chunks are missing to avoid detection errors
- update player and remote entity logic to use new chunk indexing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a03a93108325a5478ba55455fadf