### PR TITLE
Add flat ground plane and improve jump detection

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,21 +108,23 @@ async function main() {
   window.rbToMesh = rbToMesh;
   breakManager.setWorld(rapierWorld);
 
-  // Huge static ground so the blocks land (visual terrain stays as-is)
+  // Flat ground plane
   {
-    const groundRb = rapierWorld.createRigidBody(RAPIER.RigidBodyDesc.fixed().setTranslation(0, -1, 0));
+    const groundRb = rapierWorld.createRigidBody(
+      RAPIER.RigidBodyDesc.fixed().setTranslation(0, -1, 0)
+    );
     rapierWorld.createCollider(
-      RAPIER.ColliderDesc.cuboid(200, 1, 200), // half-extents
+      RAPIER.ColliderDesc.cuboid(200, 1, 200),
       groundRb
     );
 
-    // Optional: faint ground helper (invisible if you prefer)
     const ground = new THREE.Mesh(
       new THREE.PlaneGeometry(400, 400),
-      new THREE.MeshStandardMaterial({ color: 0x556b2f, metalness: 0, roughness: 1, transparent: true, opacity: 0.12 })
+      new THREE.MeshStandardMaterial({ color: 0x228B22 })
     );
     ground.rotation.x = -Math.PI / 2;
-    ground.position.y = -0.99;
+    ground.position.y = 0;
+    ground.receiveShadow = true;
     scene.add(ground);
   }
 

--- a/controls.js
+++ b/controls.js
@@ -466,9 +466,12 @@ export class PlayerControls {
       }
     }
     const expectedY = groundY + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
-    if (t.y <= expectedY + 0.15 && Math.abs(vel.y) < 0.2) {
+    const grounded = t.y <= expectedY + 0.05;
+    if (grounded) {
       this.canJump = true;
       this.hasDoubleJumped = false;
+    } else {
+      this.canJump = false;
     }
     if (t.y < expectedY) {
       this.body.setTranslation({ x: t.x, y: expectedY, z: t.z }, true);


### PR DESCRIPTION
## Summary
- Render a visible flat green ground plane and enable shadow reception.
- Improve player ground detection to reliably reset jump and run animations.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a8ec2fd483259c4f4ae9b6aa2a78