### PR TITLE
Add generic water module with lake and river support

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ import { BreakManager } from './breakManager.js';
 import { initSpeechCommands } from './speechCommands.js';
 import { LevelBuilder } from './levelBuilderMode.js';
 import { AudioManager } from './audioManager.js';
+import { generateLake } from './water.js';
 import { Spaceship } from './spaceship.js';
 import RAPIER from '@dimforge/rapier3d-compat';
 
@@ -129,17 +130,7 @@ async function main() {
   }
 
   // Central lake
-  const lakeRadius = 20;
-  const lake = new THREE.Mesh(
-    new THREE.CircleGeometry(lakeRadius, 32),
-    new THREE.MeshStandardMaterial({ color: 0x1E90FF, transparent: true, opacity: 0.7 })
-  );
-  lake.rotation.x = -Math.PI / 2;
-  lake.position.set(0, 0.01, 0);
-  scene.add(lake);
-
-  // Expose lake radius for other modules
-  window.LAKE_RADIUS = lakeRadius;
+  generateLake(scene, { x: 0, y: 0.01, z: 0 }, 20);
 
   spaceship = new Spaceship(scene, rapierWorld, rbToMesh);
   await spaceship.load();

--- a/controls.js
+++ b/controls.js
@@ -1,5 +1,6 @@
 import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
+import { isPointInWater } from './water.js';
 
 // Movement constants
 const SPEED = 5;
@@ -444,9 +445,7 @@ export class PlayerControls {
     const t = this.body.translation();
     const vel = this.body.linvel();
 
-    const lakeRadius = window.LAKE_RADIUS || 20;
-    const distFromCenter = Math.hypot(t.x, t.z);
-    this.isInWater = distFromCenter < lakeRadius;
+    this.isInWater = isPointInWater(t.x, t.z);
 
     if (this.isGrabbed) {
       // Freeze movement and follow externally provided position

--- a/water.js
+++ b/water.js
@@ -1,0 +1,67 @@
+import * as THREE from 'three';
+
+// Store all water bodies for later lookup
+const waterBodies = [];
+
+export function generateLake(scene, position, radius) {
+  const lake = new THREE.Mesh(
+    new THREE.CircleGeometry(radius, 32),
+    new THREE.MeshStandardMaterial({ color: 0x1E90FF, transparent: true, opacity: 0.7 })
+  );
+  lake.rotation.x = -Math.PI / 2;
+  lake.position.set(position.x, position.y ?? 0, position.z);
+  scene.add(lake);
+
+  waterBodies.push({
+    type: 'lake',
+    position: { x: position.x, z: position.z },
+    radius
+  });
+
+  return lake;
+}
+
+export function generateRiver(scene, position, size) {
+  const { width, length } = size;
+  const river = new THREE.Mesh(
+    new THREE.PlaneGeometry(width, length),
+    new THREE.MeshStandardMaterial({ color: 0x1E90FF, transparent: true, opacity: 0.7 })
+  );
+  river.rotation.x = -Math.PI / 2;
+  river.position.set(position.x, position.y ?? 0, position.z);
+  scene.add(river);
+
+  waterBodies.push({
+    type: 'river',
+    position: { x: position.x, z: position.z },
+    size: { width, length }
+  });
+
+  return river;
+}
+
+export function isPointInWater(x, z) {
+  for (const body of waterBodies) {
+    if (body.type === 'lake') {
+      const dx = x - body.position.x;
+      const dz = z - body.position.z;
+      if (Math.hypot(dx, dz) < body.radius) {
+        return true;
+      }
+    } else if (body.type === 'river') {
+      const halfW = body.size.width / 2;
+      const halfL = body.size.length / 2;
+      if (
+        x >= body.position.x - halfW &&
+        x <= body.position.x + halfW &&
+        z >= body.position.z - halfL &&
+        z <= body.position.z + halfL
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export { waterBodies };


### PR DESCRIPTION
## Summary
- extract swimming and lake logic into reusable `water.js`
- provide `generateLake` and `generateRiver` helpers for arbitrary water bodies
- update controls and app to use shared water detection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9bffe3b0483259bd8bd686d6d2b00