### PR TITLE
Make bottom of spaceship heavier for stability

### DIFF
--- a/spaceship.js
+++ b/spaceship.js
@@ -100,6 +100,24 @@ export class Spaceship {
       .setFriction(1);
     this.world.createCollider(colDesc, this.body);
 
+    // Add a dense collider at the bottom of the ship so the center of
+    // mass lies below the geometric center.  This makes the ship more
+    // stable while falling and encourages it to remain upright instead
+    // of flipping onto its back.
+    const ballastHeight = size.y * 0.2;
+    const ballastDesc = RAPIER.ColliderDesc.cuboid(
+      size.x * 0.2,
+      ballastHeight * 0.5,
+      size.z * 0.2
+    )
+      .setTranslation(
+        offset.x,
+        offset.y - size.y * 0.5 + ballastHeight * 0.5,
+        offset.z
+      )
+      .setDensity(10);
+    this.world.createCollider(ballastDesc, this.body);
+
     // Register with global rigid-body map so physics sync updates the mesh
     this.rbToMesh?.set(this.body, this.mesh);
 


### PR DESCRIPTION
## Summary
- add dense ballast collider to spaceship's underside to shift center of mass downward

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4a3666483258c9b3bdc544de472