### PR TITLE
Add island terrain generation and water buoyancy

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { loadMonsterModel } from "./models/monsterModel.js";
 import { createOrcVoice } from "./orcVoice.js";
-import { createClouds } from "./worldGeneration.js";
+import { createClouds, generateIsland } from "./worldGeneration.js";
 import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
@@ -14,7 +14,6 @@ import { BreakManager } from './breakManager.js';
 import { initSpeechCommands } from './speechCommands.js';
 import { LevelBuilder } from './levelBuilderMode.js';
 import { AudioManager } from './audioManager.js';
-import { generateLake } from './water.js';
 import { Spaceship } from './spaceship.js';
 import RAPIER from '@dimforge/rapier3d-compat';
 
@@ -109,7 +108,7 @@ async function main() {
   window.rbToMesh = rbToMesh;
   breakManager.setWorld(rapierWorld);
 
-  // Flat ground plane
+  // Ground collider
   {
     const groundRb = rapierWorld.createRigidBody(
       RAPIER.RigidBodyDesc.fixed().setTranslation(0, -1, 0)
@@ -118,19 +117,9 @@ async function main() {
       RAPIER.ColliderDesc.cuboid(200, 1, 200),
       groundRb
     );
-
-    const ground = new THREE.Mesh(
-      new THREE.PlaneGeometry(400, 400),
-      new THREE.MeshStandardMaterial({ color: 0x228B22 })
-    );
-    ground.rotation.x = -Math.PI / 2;
-    ground.position.y = 0;
-    ground.receiveShadow = true;
-    scene.add(ground);
   }
 
-  // Central lake
-  generateLake(scene, { x: 0, y: 0.01, z: 0 }, 20);
+  generateIsland(scene);
 
   spaceship = new Spaceship(scene, rapierWorld, rbToMesh);
   await spaceship.load();

--- a/controls.js
+++ b/controls.js
@@ -7,7 +7,6 @@ const SPEED = 5;
 const JUMP_FORCE = 5;
 const PLAYER_RADIUS = 0.3;
 const PLAYER_HALF_HEIGHT = 0.6;
-const WATER_SINK_OFFSET = 1.5;
 
 export class PlayerControls {
   constructor({ scene, camera, playerModel, renderer, multiplayer, spawnProjectile, projectiles, audioManager }) {
@@ -476,8 +475,9 @@ export class PlayerControls {
         if (hitY > groundY) groundY = hitY;
       }
     }
-    const expectedY = groundY + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
-    const grounded = t.y <= expectedY + 0.05;
+    const surfaceY = 0;
+    const expectedY = (this.isInWater ? surfaceY : groundY) + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
+    const grounded = !this.isInWater && t.y <= expectedY + 0.05;
     if (grounded && !this.isInWater) {
       this.canJump = true;
       this.hasDoubleJumped = false;
@@ -550,7 +550,7 @@ export class PlayerControls {
     const newX = t.x;
     const newY = t.y;
     const newZ = t.z;
-    const sink = this.isInWater ? WATER_SINK_OFFSET : this.waterDepth;
+    const sink = this.isInWater ? newY - surfaceY : this.waterDepth;
     const isMovingNow = movement.length() > 0;
     this.isMoving = isMovingNow;
     if (isMovingNow && this.canJump) {

--- a/water.js
+++ b/water.js
@@ -26,6 +26,14 @@ export function getWaterDepth(x, z) {
       ) {
         return MAX_LAKE_DEPTH;
       }
+    } else if (body.type === 'ocean') {
+      const dx = x - body.position.x;
+      const dz = z - body.position.z;
+      const dist = Math.hypot(dx, dz);
+      if (dist > body.innerRadius && dist < body.outerRadius) {
+        const depthRatio = (body.outerRadius - dist) / (body.outerRadius - body.innerRadius);
+        return depthRatio * MAX_LAKE_DEPTH;
+      }
     }
   }
   return 0;
@@ -66,6 +74,25 @@ export function generateRiver(scene, position, size) {
   });
 
   return river;
+}
+
+export function generateOcean(scene, position, innerRadius, outerRadius) {
+  const ocean = new THREE.Mesh(
+    new THREE.RingGeometry(innerRadius, outerRadius, 64),
+    new THREE.MeshStandardMaterial({ color: 0x1E90FF, transparent: true, opacity: 0.7, side: THREE.DoubleSide })
+  );
+  ocean.rotation.x = -Math.PI / 2;
+  ocean.position.set(position.x, position.y ?? 0, position.z);
+  scene.add(ocean);
+
+  waterBodies.push({
+    type: 'ocean',
+    position: { x: position.x, z: position.z },
+    innerRadius,
+    outerRadius
+  });
+
+  return ocean;
 }
 
 export function isPointInWater(x, z) {

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -1,6 +1,5 @@
 import * as THREE from "three";
-import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
-import RAPIER from "@dimforge/rapier3d-compat";
+import { generateOcean } from "./water.js";
 
 export function createClouds(scene) {
   const rng = () => Math.random();
@@ -34,6 +33,62 @@ export function createClouds(scene) {
     cloudGroup.position.y = 20 + rng() * 15;
     cloudGroup.rotation.y = rng() * Math.PI * 2;
     scene.add(cloudGroup);
+  }
+}
+
+export function generateIsland(scene, { islandRadius = 20, outerRadius = 100 } = {}) {
+  // Sea floor
+  const seaFloor = new THREE.Mesh(
+    new THREE.PlaneGeometry(outerRadius * 2, outerRadius * 2),
+    new THREE.MeshStandardMaterial({ color: 0x8B4513 })
+  );
+  seaFloor.rotation.x = -Math.PI / 2;
+  seaFloor.position.y = -2;
+  seaFloor.receiveShadow = true;
+  scene.add(seaFloor);
+
+  // Central island
+  const hillHeight = 6;
+  const hill = new THREE.Mesh(
+    new THREE.ConeGeometry(islandRadius, hillHeight, 32),
+    new THREE.MeshStandardMaterial({ color: 0x228B22 })
+  );
+  hill.position.y = -2 + hillHeight / 2;
+  scene.add(hill);
+
+  // Sand ring
+  const sand = new THREE.Mesh(
+    new THREE.CylinderGeometry(islandRadius + 2, islandRadius + 2, 1, 32),
+    new THREE.MeshStandardMaterial({ color: 0xC2B280 })
+  );
+  sand.position.y = -1.5;
+  scene.add(sand);
+
+  // Ocean around island
+  generateOcean(scene, { x: 0, z: 0 }, islandRadius + 2, outerRadius);
+
+  // Scatter a few small islands
+  for (let i = 0; i < 5; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const dist = islandRadius + 15 + Math.random() * (outerRadius - islandRadius - 20);
+    const x = Math.cos(angle) * dist;
+    const z = Math.sin(angle) * dist;
+    const r = 3 + Math.random() * 3;
+    const h = 2 + Math.random() * 2;
+
+    const smallSand = new THREE.Mesh(
+      new THREE.CylinderGeometry(r + 1, r + 1, 0.5, 16),
+      new THREE.MeshStandardMaterial({ color: 0xC2B280 })
+    );
+    smallSand.position.set(x, -1.75, z);
+    scene.add(smallSand);
+
+    const smallHill = new THREE.Mesh(
+      new THREE.ConeGeometry(r, h, 16),
+      new THREE.MeshStandardMaterial({ color: 0x228B22 })
+    );
+    smallHill.position.set(x, -2 + h / 2, z);
+    scene.add(smallHill);
   }
 }
 


### PR DESCRIPTION
## Summary
- Generate island terrain with sea floor, grass hill, surrounding sand, water ring, and scattered mini islands
- Add ocean water type for depth checks and rendering
- Adjust player controls to float at water surface and swim
- Integrate island generation into app bootstrap

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bae825ca048325966035140c9efa7a