### PR TITLE
Add moon rigid body with gravity and collider

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { loadMonsterModel } from "./models/monsterModel.js";
 import { createOrcVoice } from "./orcVoice.js";
-import { createClouds, generateIsland } from "./worldGeneration.js";
+import { createClouds, generateIsland, createMoon } from "./worldGeneration.js";
 import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
@@ -99,14 +99,6 @@ async function main() {
   dirLight.castShadow = true;
   scene.add(dirLight);
 
-  // Create a moon in the sky
-  const moonGeometry = new THREE.SphereGeometry(35, 32, 32);
-  const moonMaterial = new THREE.MeshStandardMaterial({ color: 0xdddddd });
-  const moon = new THREE.Mesh(moonGeometry, moonMaterial);
-  moon.position.set(0, 200, -30);
-  scene.add(moon);
-  window.moon = moon;
-
 
 
   // --- RAPIER INIT ---
@@ -128,6 +120,7 @@ async function main() {
   }
 
   generateIsland(scene);
+  createMoon(scene, rapierWorld, rbToMesh);
 
   spaceship = new Spaceship(scene, rapierWorld, rbToMesh);
   await spaceship.load();

--- a/controls.js
+++ b/controls.js
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
 import { getWaterDepth, SWIM_DEPTH_THRESHOLD } from './water.js';
+import { MOON_RADIUS } from "./worldGeneration.js";
 
 // Movement constants
 const SPEED = 5;
@@ -8,7 +9,6 @@ const JUMP_FORCE = 5;
 const PLAYER_RADIUS = 0.3;
 const PLAYER_HALF_HEIGHT = 0.6;
 const MOON_GRAVITY = 9.81;
-const MOON_RADIUS = 20;
 
 export class PlayerControls {
   constructor({ scene, camera, playerModel, renderer, multiplayer, spawnProjectile, projectiles, audioManager }) {
@@ -669,7 +669,7 @@ export class PlayerControls {
         const pos = this.body.translation();
         const playerPos = new THREE.Vector3(pos.x, pos.y, pos.z);
         const distance = playerPos.distanceTo(moon.position);
-        if (distance < MOON_RADIUS) {
+        if (distance < MOON_RADIUS * 2) {
           if (!this.moonGravityActive) {
             this.body.setGravityScale(0, true);
             this.moonGravityActive = true;

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import RAPIER from "@dimforge/rapier3d-compat";
 import { generateOcean } from "./water.js";
 
 export function createClouds(scene) {
@@ -34,6 +35,34 @@ export function createClouds(scene) {
     cloudGroup.rotation.y = rng() * Math.PI * 2;
     scene.add(cloudGroup);
   }
+}
+
+export const MOON_RADIUS = 35;
+
+export function createMoon(scene, rapierWorld, rbToMesh) {
+  const moonGeometry = new THREE.SphereGeometry(MOON_RADIUS, 32, 32);
+  const moonMaterial = new THREE.MeshStandardMaterial({ color: 0xdddddd });
+  const moon = new THREE.Mesh(moonGeometry, moonMaterial);
+  moon.position.set(0, 200, -30);
+  scene.add(moon);
+  window.moon = moon;
+
+  if (rapierWorld) {
+    const rb = rapierWorld.createRigidBody(
+      RAPIER.RigidBodyDesc.fixed().setTranslation(
+        moon.position.x,
+        moon.position.y,
+        moon.position.z
+      )
+    );
+    rapierWorld.createCollider(
+      RAPIER.ColliderDesc.ball(MOON_RADIUS),
+      rb
+    );
+    if (rbToMesh) rbToMesh.set(rb, moon);
+  }
+
+  return moon;
 }
 
 export function generateIsland(scene, { islandRadius = 20, outerRadius = 100 } = {}) {


### PR DESCRIPTION
## Summary
- Move moon creation into world generation with Rapier rigid body collider
- Use shared moon radius and improved gravity check for player controls
- Initialize moon via `createMoon` in app startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68baf404bdc08325b2d9daf527ebe74a