### PR TITLE
Implement global moon gravity

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ import { LevelBuilder } from './levelBuilderMode.js';
 import { AudioManager } from './audioManager.js';
 import { Spaceship } from './spaceship.js';
 import RAPIER from '@dimforge/rapier3d-compat';
+import { applyGlobalGravity } from "./gravity.js";
 
 const clock = new THREE.Clock();
 const mixerClock = new THREE.Clock();
@@ -568,6 +569,7 @@ async function main() {
     // Accumulate variable rAF time into fixed physics steps
     physicsAccumulator += clock.getDelta();
     while (physicsAccumulator >= FIXED_DT) {
+      applyGlobalGravity(rapierWorld, window.moon);
       rapierWorld.step();
       physicsAccumulator -= FIXED_DT;
     }

--- a/controls.js
+++ b/controls.js
@@ -1,14 +1,12 @@
 import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
 import { getWaterDepth, SWIM_DEPTH_THRESHOLD } from './water.js';
-import { MOON_RADIUS } from "./worldGeneration.js";
 
 // Movement constants
 const SPEED = 5;
 const JUMP_FORCE = 5;
 const PLAYER_RADIUS = 0.3;
 const PLAYER_HALF_HEIGHT = 0.6;
-const MOON_GRAVITY = 9.81;
 
 export class PlayerControls {
   constructor({ scene, camera, playerModel, renderer, multiplayer, spawnProjectile, projectiles, audioManager }) {
@@ -40,7 +38,6 @@ export class PlayerControls {
 
     this.isInWater = false;
     this.waterDepth = 0;
-    this.moonGravityActive = false;
 
     // Player state
     this.canJump = true;
@@ -674,29 +671,10 @@ export class PlayerControls {
         this.updateGrabbedTarget();
       }
 
-      const moon = window.moon;
-      if (moon && this.body) {
-        const pos = this.body.translation();
-        const playerPos = new THREE.Vector3(pos.x, pos.y, pos.z);
-        const distance = playerPos.distanceTo(moon.position);
-        if (distance < MOON_RADIUS * 2) {
-          if (!this.moonGravityActive) {
-            this.body.setGravityScale(0, true);
-            this.moonGravityActive = true;
-          }
-          const dir = new THREE.Vector3().subVectors(moon.position, playerPos).normalize();
-          const forceMag = this.body.mass() * MOON_GRAVITY;
-          this.body.applyTorqueImpulse({ x: dir.x * forceMag, y: dir.y * forceMag, z: dir.z * forceMag }, true);
-        } else if (this.moonGravityActive) {
-          this.body.setGravityScale(1, true);
-          this.moonGravityActive = false;
-        }
+      // Always update controls even when movement is disabled
+      if (this.controls) {
+        this.controls.update();
       }
-
-    // Always update controls even when movement is disabled
-    if (this.controls) {
-      this.controls.update();
-    }
   }
   
   getCamera() {

--- a/gravity.js
+++ b/gravity.js
@@ -1,0 +1,28 @@
+import * as THREE from "three";
+import { MOON_RADIUS } from "./worldGeneration.js";
+
+export const MOON_GRAVITY = 9.81;
+
+export function applyGlobalGravity(world, moon) {
+  if (!world || !moon) return;
+  const moonPos = moon.position;
+  world.bodies.forEach((body) => {
+    if (!body.isDynamic()) return;
+    // Remember each body's default gravity scale so we can restore it.
+    if (!body.userData) body.userData = {};
+    if (body.userData.defaultGravityScale === undefined) {
+      body.userData.defaultGravityScale = body.gravityScale();
+    }
+    const t = body.translation();
+    const pos = new THREE.Vector3(t.x, t.y, t.z);
+    const distance = pos.distanceTo(moonPos);
+    if (distance < MOON_RADIUS * 2) {
+      body.setGravityScale(0, true);
+      const dir = new THREE.Vector3().subVectors(moonPos, pos).normalize();
+      const forceMag = body.mass() * MOON_GRAVITY;
+      body.addForce({ x: dir.x * forceMag, y: dir.y * forceMag, z: dir.z * forceMag }, true);
+    } else {
+      body.setGravityScale(body.userData.defaultGravityScale, true);
+    }
+  });
+}

--- a/spaceship.js
+++ b/spaceship.js
@@ -1,9 +1,6 @@
 import * as THREE from "three";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import RAPIER from "@dimforge/rapier3d-compat";
-import { MOON_RADIUS } from "./worldGeneration.js";
-
-const MOON_GRAVITY = 9.81;
 
 export class Spaceship {
   constructor(scene, world, rbToMesh) {
@@ -21,7 +18,6 @@ export class Spaceship {
     this.fireSprite = null;
     this.smokeSprite = null;
     this.thrusting = false;
-    this.moonGravityActive = false;
   }
 
   async load() {
@@ -197,29 +193,6 @@ export class Spaceship {
       }
       this.autoStabilizeAndDrift();
 
-      const moon = window.moon;
-      if (moon) {
-        const bodyPos = this.body.translation();
-        const shipPos = new THREE.Vector3(bodyPos.x, bodyPos.y, bodyPos.z);
-        const distance = shipPos.distanceTo(moon.position);
-        if (distance < MOON_RADIUS * 2) {
-          if (!this.moonGravityActive) {
-            this.body.setGravityScale(0, true);
-            this.moonGravityActive = true;
-          }
-          const dir = new THREE.Vector3()
-            .subVectors(moon.position, shipPos)
-            .normalize();
-          const forceMag = this.body.mass() * MOON_GRAVITY;
-          this.body.applyForce(
-            { x: dir.x * forceMag, y: dir.y * forceMag, z: dir.z * forceMag },
-            true
-          );
-        } else if (this.moonGravityActive) {
-          this.body.setGravityScale(1, true);
-          this.moonGravityActive = false;
-        }
-      }
     }
 
     // this.applyWindForces();


### PR DESCRIPTION
## Summary
- Add gravity helper applying moon attraction to every dynamic Rapier body
- Call global gravity each physics tick instead of per-object moon checks
- Remove moon-specific gravity handling from player controls and spaceship

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb014cb5dc832581c02a16dc6c6e2c