### PR TITLE
Sync shared objects via host player

### DIFF
--- a/app.js
+++ b/app.js
@@ -468,6 +468,11 @@ async function main() {
       monster.userData.rb?.setTranslation(target, true);
     }
 
+    if (data.type === 'spaceship' && spaceship && !multiplayer.isHost) {
+      spaceship.body?.setTranslation({ x: data.x, y: data.y, z: data.z }, true);
+      spaceship.body?.setRotation({ x: data.rx, y: data.ry, z: data.rz, w: data.rw }, true);
+    }
+
     if (data.type === 'grab') {
       if (data.target === multiplayer.getId()) {
         playerControls.setGrabbed(data.active, data.from);
@@ -625,7 +630,23 @@ async function main() {
 
 
     playerControls.update();
-    spaceship.update();
+    if (multiplayer.isHost) {
+      spaceship.update();
+      if (spaceship.body) {
+        const t = spaceship.body.translation();
+        const r = spaceship.body.rotation();
+        multiplayer.send({
+          type: 'spaceship',
+          x: t.x,
+          y: t.y,
+          z: t.z,
+          rx: r.x,
+          ry: r.y,
+          rz: r.z,
+          rw: r.w
+        });
+      }
+    }
 
     updateHealthUI();
     if (window.localHealth <= 0 && !playerDead) {

--- a/peerConnection.js
+++ b/peerConnection.js
@@ -13,7 +13,7 @@ export class Multiplayer {
     this.connections = {};
     this.onPeerData = onPeerData;
     this.playerName = playerName;
-    this.isMonsterOwner = false;
+    this.isHost = false;
     
     this.initPeer(); // Start async setup
   }
@@ -94,20 +94,20 @@ export class Multiplayer {
         // Filter for only currently active peer IDs
         const validPeerIds = allPeerIds.filter(pid => activePeers[pid]);
 
-        // Sort by join timestamp to find the most recent
+        // Sort by join timestamp so the earliest joined peer is first
         validPeerIds.sort((a, b) => {
-          return activePeers[b]?.timestamp - activePeers[a]?.timestamp;
+          return activePeers[a]?.timestamp - activePeers[b]?.timestamp;
         });
 
         console.log("My ID:", this.id);
-        console.log("Valid Peers (latest first):", validPeerIds);
+        console.log("Valid Peers (earliest first):", validPeerIds);
 
-        // The last joined player becomes the monster owner
-        const latestPeerId = validPeerIds[0];
-        this.isMonsterOwner = (latestPeerId === this.id);
+        // The first joined player becomes the host
+        const hostPeerId = validPeerIds[0];
+        this.isHost = (hostPeerId === this.id);
 
-        if (this.isMonsterOwner) {
-          console.log("👹 I am the monster owner");
+        if (this.isHost) {
+          console.log("👑 I am the host player");
         }
 
         // Connect to any valid peers we haven't yet connected to

--- a/projectiles.js
+++ b/projectiles.js
@@ -171,7 +171,7 @@ export function updateProjectiles({
     }
   }
 
-  if (multiplayer?.isMonsterOwner && monster) {
+  if (multiplayer?.isHost && monster) {
     updateMonster(monster, clock, playerModel, otherPlayers); // pass in new args
     multiplayer.send({
       type: "monster",


### PR DESCRIPTION
## Summary
- Replace monster ownership with host player determined by earliest join
- Host controls monster and spaceship updates to sync across clients

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb265ec4648325a92439c499098153