### PR TITLE
Clamp excessive moon gravity forces

### DIFF
--- a/gravity.js
+++ b/gravity.js
@@ -2,6 +2,11 @@ import * as THREE from "three";
 import { MOON_RADIUS } from "./worldGeneration.js";
 
 export const MOON_GRAVITY = 2.0;
+// Cap the gravitational force to avoid large impulses when bodies
+// momentarily get into unstable states (e.g. a ship rotating around
+// the moon). This prevents the physics engine from applying
+// unrealistically high forces.
+const MAX_GRAVITY_FORCE = 50;
 
 export function applyGlobalGravity(world, moon) {
   if (!world || !moon) return;
@@ -19,7 +24,8 @@ export function applyGlobalGravity(world, moon) {
     if (distance < MOON_RADIUS * 2) {
       body.setGravityScale(0, true);
       const dir = new THREE.Vector3().subVectors(moonPos, pos).normalize();
-      const forceMag = body.mass() * MOON_GRAVITY;
+      let forceMag = body.mass() * MOON_GRAVITY;
+      if (forceMag > MAX_GRAVITY_FORCE) forceMag = MAX_GRAVITY_FORCE;
       body.addForce({ x: dir.x * forceMag, y: dir.y * forceMag, z: dir.z * forceMag }, true);
     } else {
       body.setGravityScale(body.userData.defaultGravityScale, true);


### PR DESCRIPTION
## Summary
- limit global moon gravity force to avoid extreme impulses when bodies rotate around the moon
- document and cap force magnitude with MAX_GRAVITY_FORCE

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb2740df208325a1e8015915d2e177