### PR TITLE
Reset moon rotation and add parachute

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,7 +412,13 @@ async function main() {
             .normalize();
           const target = playerPos.clone().add(forward);
           player.model.lookAt(target);
+        } else {
+          player.model.up.set(0, 1, 0);
+          player.model.quaternion.setFromAxisAngle(new THREE.Vector3(0, 1, 0), data.rotation);
         }
+      } else {
+        player.model.up.set(0, 1, 0);
+        player.model.quaternion.setFromAxisAngle(new THREE.Vector3(0, 1, 0), data.rotation);
       }
 
       // Sync animation state if provided

--- a/spaceship.js
+++ b/spaceship.js
@@ -376,9 +376,16 @@ export class Spaceship {
   dismount() {
     if (!this.occupant) return;
     const playerControls = this.occupant;
-    const top = this.mesh
-      ? this.mesh.position.clone().add(this.mountOffset)
-      : new THREE.Vector3();
+    let top = new THREE.Vector3();
+    if (this.mesh) {
+      this.mesh.updateMatrixWorld(true);
+      const bbox = new THREE.Box3().setFromObject(this.mesh);
+      top.set(
+        (bbox.min.x + bbox.max.x) / 2,
+        bbox.max.y + 2,
+        (bbox.min.z + bbox.max.z) / 2
+      );
+    }
     if (playerControls.playerModel) {
       playerControls.playerModel.position.copy(top);
     }
@@ -389,6 +396,7 @@ export class Spaceship {
         playerControls.body.setLinvel(vel, true);
       }
     }
+    playerControls.deployParachute?.();
     playerControls.vehicle = null;
     this.occupant = null;
   }


### PR DESCRIPTION
## Summary
- Reset player and camera orientation to world up when far from the moon
- Place player above spaceship on dismount and deploy a simple parachute
- Allow spacebar to remove parachute

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb2babcbb48325b8931759897afddb