### PR TITLE
Add continuous water and underwater movement

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
-import { getWaterDepth, SWIM_DEPTH_THRESHOLD } from './water.js';
+import { getWaterDepth, SWIM_DEPTH_THRESHOLD, getTerrainHeight } from './water.js';
 import { MOON_RADIUS } from "./worldGeneration.js";
 
 // Movement constants
@@ -472,7 +472,7 @@ export class PlayerControls {
       return;
     }
 
-    const terrainY = 0;
+    const terrainY = getTerrainHeight(t.x, t.z);
     let groundY = terrainY;
     const world = window.rapierWorld;
     if (world) {
@@ -493,7 +493,12 @@ export class PlayerControls {
       this.canJump = false;
     }
     if (this.isInWater) {
-      if (t.y < floatTargetY) {
+      if (this.keysPressed.has(" ")) {
+        const newY = t.y - 0.2;
+        this.body.setTranslation({ x: t.x, y: newY, z: t.z }, true);
+        this.body.setLinvel({ x: vel.x, y: -1, z: vel.z }, true);
+        t.y = newY;
+      } else if (t.y < floatTargetY) {
         const newY = t.y + (floatTargetY - t.y) * 0.1;
         this.body.setTranslation({ x: t.x, y: newY, z: t.z }, true);
         if (vel.y < 0) {

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
-import { generateOcean } from "./water.js";
+import { generateOcean, registerIsland, SEA_FLOOR_Y } from "./water.js";
 
 export function createClouds(scene) {
   const rng = () => Math.random();
@@ -73,10 +73,10 @@ export function generateIsland(scene, { islandRadius = 20, outerRadius = 100 } =
   // Sea floor
   const seaFloor = new THREE.Mesh(
     new THREE.PlaneGeometry(outerRadius * 2, outerRadius * 2),
-    new THREE.MeshStandardMaterial({ color: 0x8B4513 })
+    new THREE.MeshStandardMaterial({ color: 0x00008B })
   );
   seaFloor.rotation.x = -Math.PI / 2;
-  seaFloor.position.y = -2;
+  seaFloor.position.y = SEA_FLOOR_Y;
   seaFloor.receiveShadow = true;
   scene.add(seaFloor);
 
@@ -86,19 +86,12 @@ export function generateIsland(scene, { islandRadius = 20, outerRadius = 100 } =
     new THREE.ConeGeometry(islandRadius, hillHeight, 32),
     new THREE.MeshStandardMaterial({ color: 0x228B22 })
   );
-  hill.position.y = -2 + hillHeight / 2;
+  hill.position.y = SEA_FLOOR_Y + hillHeight / 2;
   scene.add(hill);
-
-  // Sand ring
-  const sand = new THREE.Mesh(
-    new THREE.CylinderGeometry(islandRadius + 2, islandRadius + 2, 1, 32),
-    new THREE.MeshStandardMaterial({ color: 0xC2B280 })
-  );
-  sand.position.y = -1.5;
-  scene.add(sand);
+  registerIsland({ x: 0, z: 0 }, islandRadius, hillHeight);
 
   // Ocean around island
-  generateOcean(scene, { x: 0, z: 0 }, islandRadius + 2, outerRadius);
+  generateOcean(scene, { x: 0, z: 0 }, 0, outerRadius);
 
   // Scatter a few small islands
   for (let i = 0; i < 5; i++) {
@@ -107,21 +100,15 @@ export function generateIsland(scene, { islandRadius = 20, outerRadius = 100 } =
     const x = Math.cos(angle) * dist;
     const z = Math.sin(angle) * dist;
     const r = 3 + Math.random() * 3;
-    const h = 2 + Math.random() * 2;
-
-    const smallSand = new THREE.Mesh(
-      new THREE.CylinderGeometry(r + 1, r + 1, 0.5, 16),
-      new THREE.MeshStandardMaterial({ color: 0xC2B280 })
-    );
-    smallSand.position.set(x, -1.75, z);
-    scene.add(smallSand);
+    const h = 3 + Math.random() * 2;
 
     const smallHill = new THREE.Mesh(
       new THREE.ConeGeometry(r, h, 16),
       new THREE.MeshStandardMaterial({ color: 0x228B22 })
     );
-    smallHill.position.set(x, -2 + h / 2, z);
+    smallHill.position.set(x, SEA_FLOOR_Y + h / 2, z);
     scene.add(smallHill);
+    registerIsland({ x, z }, r, h);
   }
 }
 


### PR DESCRIPTION
## Summary
- Render a dark blue sea floor and generate sloped islands rising from it
- Use a continuous ocean surface hidden beneath islands
- Allow players to float in water and swim downward when pressing space

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb374aee80832592d42931b5306ebb