### PR TITLE
Replace water with Water2 and add buoyancy

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
-import { getWaterDepth, SWIM_DEPTH_THRESHOLD, getTerrainHeight } from './water.js';
+import { getWaterDepth, SWIM_DEPTH_THRESHOLD, getTerrainHeight, getWaterHeight } from './water.js';
 import { MOON_RADIUS } from "./worldGeneration.js";
 
 // Movement constants
@@ -460,7 +460,7 @@ export class PlayerControls {
     const vel = this.body.linvel();
 
     this.waterDepth = getWaterDepth(t.x, t.z);
-    const surfaceY = 0;
+    const surfaceY = getWaterHeight(t.x, t.z);
     const floatTargetY = surfaceY + PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
     this.isInWater = this.waterDepth > SWIM_DEPTH_THRESHOLD && t.y < floatTargetY;
 

--- a/projectiles.js
+++ b/projectiles.js
@@ -1,6 +1,7 @@
 import * as THREE from "three";
 import RAPIER from '@dimforge/rapier3d-compat';
 import { updateMonster, switchMonsterAnimation } from './characters/MonsterCharacter.js';
+import { isPointInWater, getWaterHeight, pushWater } from './water.js';
 
 export function spawnProjectile(scene, projectiles, position, direction) {
   const size = 0.5;
@@ -75,6 +76,8 @@ export function updateProjectiles({
     }
 
     const vel = new THREE.Vector3(linvel.x, linvel.y, linvel.z);
+    const pos = rb.translation();
+    proj.position.set(pos.x, pos.y, pos.z);
     proj.userData.velocity = vel.clone();
 
     proj.userData.lifetime -= 16;
@@ -168,6 +171,13 @@ export function updateProjectiles({
 
         }
       }
+    }
+
+    if (removed) continue;
+    if (isPointInWater(pos.x, pos.z) && pos.y <= getWaterHeight(pos.x, pos.z)) {
+      pushWater({ x: pos.x, z: pos.z }, vel, { length: 2, width: 1, strength: 1 });
+      removeProjectile(i);
+      continue;
     }
   }
 


### PR DESCRIPTION
## Summary
- Render lakes, rivers, and ocean using three.js Water2 with CPU Gerstner waves for buoyancy
- Float players and monsters on the water surface and slow their movement when swimming
- Spawn Water2 ripples when projectiles impact the water

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06dcaf9a48325bce67ec44826097e