### PR TITLE
Simplify surfboard to visual accessory

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { loadMonsterModel } from "./models/monsterModel.js";
 import { createOrcVoice } from "./orcVoice.js";
 import { createClouds, generateIsland, createMoon, MOON_RADIUS } from "./worldGeneration.js";
-import { isPointInWater, initWaves, spawnOceanWave, updateWaves, getWaveForceAt } from './water.js';
+import { initWaves, spawnOceanWave, updateWaves, getWaveForceAt } from './water.js';
 import { Multiplayer } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
@@ -133,7 +133,7 @@ async function main() {
   await spaceship.load();
   window.spaceship = spaceship;
 
-  surfboard = new Surfboard(scene, rapierWorld, rbToMesh);
+  surfboard = new Surfboard(scene);
   await surfboard.load();
   window.surfboard = surfboard;
 
@@ -201,7 +201,7 @@ async function main() {
   }
 
   function applyWaveForces() {
-    if (playerControls.body && playerControls.isInWater && (!playerControls.vehicle || playerControls.vehicle.type !== 'surfboard')) {
+    if (playerControls.body && playerControls.isInWater) {
       const t = playerControls.body.translation();
       const f = getWaveForceAt(t.x, t.z);
       if (f.x !== 0 || f.z !== 0) {
@@ -209,15 +209,6 @@ async function main() {
       }
     }
 
-    if (surfboard?.body) {
-      const t = surfboard.body.translation();
-      if (isPointInWater(t.x, t.z)) {
-        const f = getWaveForceAt(t.x, t.z);
-        if (f.x !== 0 || f.z !== 0) {
-          surfboard.body.applyImpulse({ x: f.x, y: 0, z: f.z }, true);
-        }
-      }
-    }
   }
 
 

--- a/controls.js
+++ b/controls.js
@@ -286,10 +286,6 @@ export class PlayerControls {
           this.vehicle.dismount();
           return;
         }
-        if (this.vehicle.type === 'surfboard' && key === 'e') {
-          this.vehicle.toggleStand();
-          return;
-        }
         return;
       }
 
@@ -499,7 +495,7 @@ export class PlayerControls {
     } else {
       this.canJump = false;
     }
-    if (this.isInWater && (!this.vehicle || this.vehicle.type !== 'surfboard')) {
+    if (this.isInWater) {
       if (this.keysPressed.has(" ")) {
         const newY = t.y - 0.2;
         this.body.setTranslation({ x: t.x, y: newY, z: t.z }, true);
@@ -575,11 +571,6 @@ export class PlayerControls {
       }
     } else {
       const speed = this.isInWater ? SWIM_SPEED : SPEED;
-      if (this.vehicle && this.vehicle.type === 'surfboard' && this.vehicle.standing) {
-        // Delegate surfboard standing controls (handles keys internally)
-        this.vehicle.handleControls(this);
-        return;
-      }
       this.body.setLinvel({ x: movement.x * speed, y: vel.y, z: movement.z * speed }, true);
       }
     const newX = t.x;

--- a/surfboard.js
+++ b/surfboard.js
@@ -1,315 +1,72 @@
 import * as THREE from 'three';
-import RAPIER from '@dimforge/rapier3d-compat';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { getWaterDepth, getTerrainHeight } from './water.js';
 
 export class Surfboard {
-  constructor(scene, world, rbToMesh) {
+  constructor(scene) {
     this.scene = scene;
-    this.world = world;
-    this.rbToMesh = rbToMesh;
     this.mesh = null;
-    this.body = null;
-    this.collider = null;
     this.occupant = null;
-    this.mountOffset = new THREE.Vector3(-0.7, 0.3, -1.2);
     this.type = 'surfboard';
-    this.standing = false;
-    this.prevKeys = new Set();
-    this.nextPumpTime = 0;
-    this.pumpCooldownMs = 700;
-    this.lowSpeedTime = 0;
-    this.lastUpdateTs = performance.now();
+    this.holdingOffset = new THREE.Vector3(0.5, 0.1, -0.5);
+    this.swimOffset = new THREE.Vector3(0, -0.4, 0.8);
   }
 
   async load(position = { x: 0, y: 0, z: 0 }) {
     try {
       const loader = new GLTFLoader();
       const gltf = await loader.loadAsync('/assets/props/surfboard__tabla_de_surf.glb');
-      
       this.mesh = gltf.scene;
-      this.scene.add(this.mesh);
-      this.mesh.position.set(0, 0, 0);
-      this.mesh.scale.set(1, 1, 1);
-      this.mesh.updateMatrixWorld(true);
-      this.mesh.scale.setScalar(0.008);     
-
+      this.mesh.scale.setScalar(0.008);
     } catch (e) {
-      // Fallback to simple box if the GLB is missing or fails to load
       const geometry = new THREE.BoxGeometry(2, 0.1, 0.5);
       const material = new THREE.MeshStandardMaterial({ color: 0xffe0bd });
       this.mesh = new THREE.Mesh(geometry, material);
     }
+    this.mesh.position.set(position.x, position.y, position.z);
     this.mesh.castShadow = true;
-    
-    // Compute bounding box for camera and collider setup
-    this.mesh.updateMatrixWorld(true);
-    const bbox = new THREE.Box3().setFromObject(this.mesh);
-    const size = new THREE.Vector3();
-    const center = new THREE.Vector3();
-    bbox.getSize(size);
-    bbox.getCenter(center);
-    this.boundingSize = size;
-    this.boundingCenterOffset = new THREE.Vector3().subVectors(center, this.mesh.position);
-
-    const rbDesc = RAPIER.RigidBodyDesc.dynamic()
-      .setTranslation(position.x, position.y, position.z)
-      .setLinearDamping(2)
-      .setAngularDamping(2)
-      .setGravityScale(0);
-    this.body = this.world.createRigidBody(rbDesc);
-
-    const tilt = new THREE.Quaternion().setFromAxisAngle(
-      new THREE.Vector3(1, 0, 0),
-      -Math.PI / 2
-    );
-    this.body.setRotation({ x: tilt.x, y: tilt.y, z: tilt.z, w: tilt.w }, false);
-
-    // Only allow yaw
-    this.body.setEnabledRotations(false, true, false, true);
-
-    // Use a cuboid collider approximating the model's bounding box
-    const colDesc = RAPIER.ColliderDesc.cuboid(
-      size.x / 2,
-      size.y / 2,
-      size.z / 2
-    )
-      .setTranslation(
-        this.boundingCenterOffset.x,
-        this.boundingCenterOffset.y,
-        this.boundingCenterOffset.z
-      )
-      .setRestitution(0)
-      .setFriction(1);
-    this.collider = this.world.createCollider(colDesc, this.body);
-
-    this.rbToMesh?.set(this.body, this.mesh);
+    this.mesh.rotation.set(-Math.PI / 2, 0, 0);
+    this.scene.add(this.mesh);
   }
 
   tryMount(playerControls) {
-    if (this.occupant || !playerControls?.playerModel || !this.body) return;
+    if (this.occupant || !playerControls?.playerModel) return;
     const dist = playerControls.playerModel.position.distanceTo(this.mesh.position);
     if (dist < 3) {
       this.occupant = playerControls;
       playerControls.vehicle = this;
-
-      // Make the surfboard follow the player kinematically and avoid
-      // colliding with them. The player keeps their own physics body.
-      this._savedBoardType = this.body.bodyType();
-      this.body.setBodyType(RAPIER.RigidBodyType.KinematicPositionBased, true);
-      if (this.collider) {
-        this._savedSensor = this.collider.isSensor();
-        this.collider.setSensor(true);
-      }
     }
   }
-
 
   dismount() {
     if (!this.occupant) return;
     this.occupant.vehicle = null;
     this.occupant = null;
-    this.standing = false;
-
-    // Restore surfboard physics settings
-    if (this._savedBoardType !== undefined) {
-      this.body.setBodyType(this._savedBoardType, true);
-      this._savedBoardType = undefined;
-    }
-    if (this.collider && this._savedSensor !== undefined) {
-      this.collider.setSensor(this._savedSensor);
-      this._savedSensor = undefined;
-    }
-  }
-
-
-  toggleStand() {
-    if (!this.occupant) return;
-    this.standing = !this.standing;
-    const actions = this.occupant.playerModel?.userData?.actions;
-    const current = this.occupant.playerModel?.userData?.currentAction;
-    if (actions) {
-      const target = this.standing ? 'idle' : 'swim';
-      if (current !== target) {
-        actions[current]?.fadeOut(0.2);
-        actions[target]?.reset().fadeIn(0.2).play();
-        this.occupant.playerModel.userData.currentAction = target;
-      }
-    }
-  }
-
-  handleControls(playerControls) {
-    if (!this.body || !this.occupant) return;
-    // Only special handling when standing
-    if (!this.standing) return;
-
-    const now = performance.now();
-    const dt = Math.min(0.05, (now - (this._lastControlsTs || now)) / 1000);
-    this._lastControlsTs = now;
-
-    const keys = playerControls.keysPressed || new Set();
-
-    // Extract yaw-only forward/right from body rotation
-    const rot = this.body.rotation();
-    const q = new THREE.Quaternion(rot.x, rot.y, rot.z, rot.w);
-    const e = new THREE.Euler().setFromQuaternion(q, 'YXZ');
-    let yaw = e.y;
-    const forward = new THREE.Vector3(0, 0, 1).applyEuler(new THREE.Euler(0, yaw, 0));
-    const right = new THREE.Vector3(1, 0, 0).applyEuler(new THREE.Euler(0, yaw, 0));
-    const left = right.clone().multiplyScalar(-1);
-
-    // Rotation with A/D and lateral push while pressed
-    const yawRate = 1.5; // rad/s
-    const lateralPush = 0.5; // impulse strength per tick when held
-    let yawDelta = 0;
-    if (keys.has('a')) {
-      yawDelta -= yawRate * dt;
-      this.body.applyImpulse({ x: left.x * lateralPush, y: 0, z: left.z * lateralPush }, true);
-    }
-    if (keys.has('d')) {
-      yawDelta += yawRate * dt;
-      this.body.applyImpulse({ x: right.x * lateralPush, y: 0, z: right.z * lateralPush }, true);
-    }
-    if (yawDelta !== 0) {
-      yaw += yawDelta;
-      const yawQ = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, yaw, 0, 'YXZ'));
-      this.body.setRotation({ x: yawQ.x, y: yawQ.y, z: yawQ.z, w: yawQ.w }, true);
-    }
-
-    // W pump: short forward impulse on key press with cooldown
-    const pumpImpulse = 6.0;
-    if (keys.has('w') && !this.prevKeys.has('w') && now >= this.nextPumpTime) {
-      this.body.applyImpulse({ x: forward.x * pumpImpulse, y: 0, z: forward.z * pumpImpulse }, true);
-      this.nextPumpTime = now + this.pumpCooldownMs;
-    }
-
-    // S brake: small continuous push against forward while held
-    const brakePush = 1.8;
-    if (keys.has('s')) {
-      this.body.applyImpulse({ x: -forward.x * brakePush, y: 0, z: -forward.z * brakePush }, true);
-    }
-
-    // Face the rider toward movement direction
-    const lv = this.body.linvel();
-    const speedXY = Math.hypot(lv.x, lv.z);
-    if (this.occupant?.playerModel) {
-      let faceYaw = yaw;
-      if (speedXY > 0.05) {
-        faceYaw = Math.atan2(lv.x, lv.z);
-      }
-      this.occupant.playerModel.rotation.set(0, faceYaw, 0);
-      const actions = this.occupant.playerModel.userData?.actions;
-      const current = this.occupant.playerModel.userData?.currentAction;
-      if (actions && current !== 'idle') {
-        actions[current]?.fadeOut(0.2);
-        actions['idle']?.reset().fadeIn(0.2).play();
-        this.occupant.playerModel.userData.currentAction = 'idle';
-      }
-    }
-
-    // Remember keys for edge detection
-    this.prevKeys = new Set(keys);
-  }
-
-  applyInput(moveVec) {
-    if (!this.body) return;
-    const speed = 15; // Surfing speed
-    const vel = moveVec.clone().multiplyScalar(speed);
-    this.body.setLinvel({ x: vel.x, y: 0, z: vel.z }, true);
   }
 
   update() {
-    if (!this.body) return;
-    const now = performance.now();
-    const dt = Math.min(0.1, (now - this.lastUpdateTs) / 1000);
-    this.lastUpdateTs = now;
-
-    const t = this.body.translation();
-    const lv = this.body.linvel();
-    const rv = this.body.angvel ? this.body.angvel() : { x: 0, y: 0, z: 0 };
-
-    // Determine environment
-    const waterDepth = getWaterDepth(t.x, t.z);
-    const onWater = waterDepth > 0;
-    const halfThickness = 0.05; // collider half-height
-
-    if (onWater) {
-      const targetY = 0 + halfThickness;
-      if (t.y !== targetY) {
-        this.body.setTranslation({ x: t.x, y: targetY, z: t.z }, true);
-      }
-      // No vertical motion on water
-      if (lv.y !== 0) {
-        this.body.setLinvel({ x: lv.x, y: 0, z: lv.z }, true);
-      }
-    } else {
-      const terrainY = getTerrainHeight(t.x, t.z) + halfThickness;
-      if (t.y !== terrainY) {
-        this.body.setTranslation({ x: t.x, y: terrainY, z: t.z }, true);
-      }
-      if (!this.occupant) {
-        // Stay still on land unless mounted
-        if (lv.x !== 0 || lv.y !== 0 || lv.z !== 0) {
-          this.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-        }
-        if (rv.x !== 0 || rv.y !== 0 || rv.z !== 0) {
-          this.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
-        }
-      }
-    }
+    if (!this.mesh) return;
 
     if (this.occupant) {
-      // Drive the board to match the player's position and yaw.
-      const riderT = this.occupant.body
-        ? this.occupant.body.translation()
-        : this.occupant.playerModel.position;
-      const yaw = this.occupant.playerModel.rotation.y;
-      const yawQ = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, yaw, 0, 'YXZ'));
-
-      const offset = this.mountOffset.clone().applyQuaternion(yawQ);
-      const boardPos = {
-        x: riderT.x - offset.x,
-        y: riderT.y - offset.y,
-        z: riderT.z - offset.z,
-      };
-
-      this.body.setNextKinematicTranslation(boardPos);
-      this.body.setNextKinematicRotation({
-        x: yawQ.x,
-        y: yawQ.y,
-        z: yawQ.z,
-        w: yawQ.w,
-      });
-
-      // When standing, ensure the rider's animation stays idle
-      if (this.standing && this.occupant.playerModel) {
-        const actions = this.occupant.playerModel.userData.actions;
-        const current = this.occupant.playerModel.userData.currentAction;
-        if (actions && current !== 'idle') {
-          actions[current]?.fadeOut(0.2);
-          actions.idle?.reset().fadeIn(0.2).play();
-          this.occupant.playerModel.userData.currentAction = 'idle';
-        }
-      }
-    }
-
-    // Auto-dismount with fall-flat if speed too low while standing
-    if (this.standing && this.occupant) {
-      const v = this.body.linvel();
-      const speed = Math.hypot(v.x, v.z);
-      const threshold = 0.2;
-      if (speed < threshold) {
-        this.lowSpeedTime += dt;
-        if (this.lowSpeedTime > 0.4) {
-          const rider = this.occupant;
-          this.dismount();
-          rider.playAction?.('hit');
-        }
-      } else {
-        this.lowSpeedTime = 0;
-      }
+      const player = this.occupant;
+      const basePos = player.playerModel.position;
+      const yaw = player.playerModel.rotation.y;
+      const yawQ = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), yaw);
+      const offset = (player.isInWater ? this.swimOffset : this.holdingOffset)
+        .clone()
+        .applyQuaternion(yawQ);
+      this.mesh.position.copy(basePos).add(offset);
+      this.mesh.rotation.set(-Math.PI / 2, yaw, 0);
     } else {
-      this.lowSpeedTime = 0;
+      const t = this.mesh.position;
+      const waterDepth = getWaterDepth(t.x, t.z);
+      const onWater = waterDepth > 0;
+      const halfThickness = 0.05;
+      if (onWater) {
+        this.mesh.position.y = 0 + halfThickness;
+      } else {
+        this.mesh.position.y = getTerrainHeight(t.x, t.z) + halfThickness;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove surfboard physics and controls, keeping it as a visual accessory that follows the player
- Simplify player handling by removing surfboard-specific logic and always using water movement/animations
- Trim wave force handling to ignore surfboard and consistently apply to player

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4843f910883258a363f6f8bb41e33