### PR TITLE
Implement hilly island terrain generation

### DIFF
--- a/water.js
+++ b/water.js
@@ -12,29 +12,34 @@ export const SWIM_DEPTH_THRESHOLD = 0.7;
 
 function isPointOnIsland(x, z) {
   for (const island of islandAreas) {
-    const dx = x - island.x;
-    const dz = z - island.z;
+    const dx = x - island.center.x;
+    const dz = z - island.center.z;
     const dist = Math.hypot(dx, dz);
     if (dist < island.surfaceRadius) return true;
   }
   return false;
 }
 
-export function registerIsland(position, baseRadius, height) {
-  const waterLevel = 0;
-  const surfaceRadius = baseRadius * (1 - (waterLevel - SEA_FLOOR_Y) / height);
-  islandAreas.push({ x: position.x, z: position.z, baseRadius, height, surfaceRadius });
+export function registerIsland({ center, radius, surfaceRadius = radius, getHeight }) {
+  islandAreas.push({
+    center: { x: center.x, z: center.z },
+    radius,
+    surfaceRadius,
+    getHeight,
+  });
 }
 
 export function getTerrainHeight(x, z) {
   let height = SEA_FLOOR_Y;
   for (const island of islandAreas) {
-    const dx = x - island.x;
-    const dz = z - island.z;
+    const dx = x - island.center.x;
+    const dz = z - island.center.z;
     const dist = Math.hypot(dx, dz);
-    if (dist < island.baseRadius) {
-      const h = SEA_FLOOR_Y + island.height * (1 - dist / island.baseRadius);
-      if (h > height) height = h;
+    if (dist <= island.radius) {
+      if (typeof island.getHeight === 'function') {
+        const h = island.getHeight(x, z);
+        if (h > height) height = h;
+      }
     }
   }
   return height;


### PR DESCRIPTION
## Summary
- replace the cylindrical island meshes with procedurally generated hilly terrain that eases down to the sea floor
- apply the new sand, ground, and rock textures from `public/assets/textures` to the terrain and seafloor materials
- expose sampled height data per island so `getTerrainHeight` keeps players and monsters aligned with the hills

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d48c20ecb083259492cc6d2dd844a0