### PR TITLE
Add ice gun ammo tracking and pickups

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
   </div>
   <div id="interaction-tooltip" class="interaction-tooltip"></div>
   <div id="health-bar"><div id="health-fill"></div></div>
+  <div id="ammo-display" class="inactive">
+    <span id="ammo-icon">❄️</span>
+    <span id="ammo-count">0</span>
+  </div>
   <div id="action-buttons">
     <button id="voice-button" class="action-button">Unmute</button>
     <button id="talk-button" class="action-button">🎤</button>

--- a/styles.css
+++ b/styles.css
@@ -263,6 +263,37 @@ body {
   width: 100%;
 }
 
+#ammo-display {
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 2px solid #000;
+  border-radius: 6px;
+  color: #fff;
+  font-family: 'Press Start 2P', sans-serif;
+  font-size: 12px;
+  z-index: 1000;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+#ammo-icon {
+  font-size: 16px;
+}
+
+#ammo-display.inactive {
+  opacity: 0.4;
+  transform: scale(0.95);
+}
+
+#ammo-display.empty {
+  color: #ff9b9b;
+}
+
 #voice-button {
 }
 


### PR DESCRIPTION
## Summary
- restrict projectile firing to when the player holds the ice gun and has available ammo
- surface an on-screen ammo indicator that reflects the current magazine state
- spawn animated ammo pickups that refill the ice gun when collected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d969c06a2083258b1375bf7055ff69