### PR TITLE
Ensure monster spawn uses terrain-aware positions

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ import { RowBoat } from './rowboat.js';
 import { IceGun } from './iceGun.js';
 import RAPIER from '@dimforge/rapier3d-compat';
 import { applyGlobalGravity } from "./gravity.js";
+import { getSpawnPosition } from './spawnUtils.js';
 
 const clock = new THREE.Clock();
 const mixerClock = new THREE.Clock();
@@ -75,6 +76,13 @@ async function main() {
     monster.userData.speed = 0.025;
     monster.userData.lastDirectionChange = Date.now();
     monster.userData.mode = "friendly"; // default behavior
+
+    const monsterSpawn = getSpawnPosition({ heightOffset: 0.5 });
+    monster.position.set(monsterSpawn.x, monsterSpawn.y, monsterSpawn.z);
+    monster.userData.spawnPoint = monsterSpawn;
+    if (monster.userData.rb) {
+      monster.userData.rb.setTranslation({ x: monsterSpawn.x, y: monsterSpawn.y, z: monsterSpawn.z }, true);
+    }
 
     const orcPhrases = [
       "Uggghh",
@@ -393,14 +401,17 @@ async function main() {
   function respawnPlayer() {
     window.localHealth = 100;
     updateHealthUI();
-    const newX = (Math.random() * 10) - 5;
-    const newZ = (Math.random() * 10) - 5;
-    const newY = 0.5;
-    playerModel.position.set(newX, newY, newZ);
-    playerControls.playerX = newX;
-    playerControls.playerY = newY;
-    playerControls.playerZ = newZ;
-    playerControls.lastPosition.set(newX, newY, newZ);
+    const spawn = getSpawnPosition();
+    playerModel.position.set(spawn.x, spawn.y, spawn.z);
+    playerControls.playerX = spawn.x;
+    playerControls.playerY = spawn.y;
+    playerControls.playerZ = spawn.z;
+    playerControls.lastPosition.set(spawn.x, spawn.y, spawn.z);
+    if (playerControls.body) {
+      playerControls.body.setTranslation({ x: spawn.x, y: spawn.y, z: spawn.z }, true);
+      playerControls.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+      playerControls.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+    }
     playerControls.velocity.set(0, 0, 0);
     playerControls.enabled = true;
     playerDead = false;

--- a/controls.js
+++ b/controls.js
@@ -2,6 +2,7 @@ import * as THREE from "three";
 import RAPIER from "@dimforge/rapier3d-compat";
 import { getWaterDepth, SWIM_DEPTH_THRESHOLD, getTerrainHeight } from './water.js';
 import { MOON_RADIUS } from "./worldGeneration.js";
+import { getSpawnPosition } from './spawnUtils.js';
 
 // Movement constants
 const SPEED = 5;
@@ -63,10 +64,10 @@ export class PlayerControls {
     this.moveRight = 0;
     
     // Initial player position
-    // const initialPos = { x: 0, y: 0.5, z: 0 };
-    this.playerX = (Math.random() * 10) - 5;
-    this.playerZ = (Math.random() * 10) - 5;
-    this.playerY = 0.5;
+    const spawn = getSpawnPosition();
+    this.playerX = spawn.x;
+    this.playerY = spawn.y;
+    this.playerZ = spawn.z;
 
     
     // Set initial player model position if it exists

--- a/spawnUtils.js
+++ b/spawnUtils.js
@@ -1,0 +1,48 @@
+import { getTerrainHeight, getWaterDepth } from './water.js';
+
+const DEFAULT_RADIUS = 12;
+const MAX_ATTEMPTS = 30;
+const DEFAULT_HEIGHT_OFFSET = 0.6;
+const WATER_THRESHOLD = 0.1;
+
+function sampleXZ(radius) {
+  const angle = Math.random() * Math.PI * 2;
+  const distance = Math.random() * radius;
+  const x = Math.cos(angle) * distance;
+  const z = Math.sin(angle) * distance;
+  return { x, z };
+}
+
+export function getSpawnPosition({
+  radius = DEFAULT_RADIUS,
+  heightOffset = DEFAULT_HEIGHT_OFFSET,
+  maxAttempts = MAX_ATTEMPTS,
+  allowWater = false,
+} = {}) {
+  let fallback = null;
+  for (let i = 0; i < maxAttempts; i += 1) {
+    const { x, z } = sampleXZ(radius);
+    const terrainY = getTerrainHeight(x, z);
+    const waterDepth = getWaterDepth(x, z);
+    if (!allowWater && waterDepth > WATER_THRESHOLD) {
+      if (!fallback) fallback = { x, z, terrainY };
+      continue;
+    }
+    return { x, y: terrainY + heightOffset, z, terrainY };
+  }
+
+  if (fallback) {
+    const { x, z, terrainY } = fallback;
+    return { x, y: terrainY + heightOffset, z, terrainY };
+  }
+
+  const originTerrain = getTerrainHeight(0, 0);
+  return { x: 0, y: originTerrain + heightOffset, z: 0, terrainY: originTerrain };
+}
+
+export function snapObjectToTerrain(object, { heightOffset = DEFAULT_HEIGHT_OFFSET } = {}) {
+  if (!object) return;
+  const { x, z } = object.position;
+  const terrainY = getTerrainHeight(x, z);
+  object.position.y = terrainY + heightOffset;
+}


### PR DESCRIPTION
## Summary
- add a shared spawn utility that samples island terrain heights
- initialize the local player, respawns, and the monster using the shared helper
- reset player physics state on respawn so bodies sync with the new spawn point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d972b3938483258a97150b96dcbdf9