### PR TITLE
Fix monster falling through terrain

### DIFF
--- a/app.js
+++ b/app.js
@@ -691,7 +691,7 @@ async function main() {
       if (!mesh.userData?.isTerrain) {
         mesh.updateMatrixWorld();
         const bbox = new THREE.Box3().setFromObject(mesh);
-        const terrainY = 0;
+        const terrainY = getTerrainHeight(mesh.position.x, mesh.position.z);
         if (bbox.min.y < terrainY) {
           const correction = terrainY - bbox.min.y;
           mesh.position.y += correction;


### PR DESCRIPTION
## Summary
- clamp all physics-driven meshes to the sampled terrain height instead of a hardcoded ground level
- keep rigid bodies from continuing downward motion once adjusted to the terrain surface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9778005e88325884ba973bd973090