### PR TITLE
Increase monster movement speeds

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,11 @@ async function main() {
     monster.userData.actions = data.actions;
     monster.userData.currentAction = "Idle";
     monster.userData.direction = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
-    monster.userData.speed = 0.025;
+    // Tune monster movement speeds so it doesn't feel stuck in slow motion.
+    // "wanderSpeed" is used while the monster roams around in friendly mode,
+    // while "chaseSpeed" is used when it targets players in enemy mode.
+    monster.userData.wanderSpeed = 0.04;
+    monster.userData.chaseSpeed = 0.14;
     monster.userData.lastDirectionChange = Date.now();
     monster.userData.mode = "friendly"; // default behavior
 

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -62,7 +62,8 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
     }
 
     const vel = body.linvel();
-    const movement = data.direction.clone().multiplyScalar(data.speed);
+    const wanderSpeed = data.wanderSpeed ?? data.speed ?? 0.025;
+    const movement = data.direction.clone().multiplyScalar(wanderSpeed);
     body.setLinvel({ x: movement.x, y: vel.y, z: movement.z }, true);
     const angle = Math.atan2(data.direction.x, data.direction.z);
     const rot = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, angle, 0));
@@ -100,7 +101,8 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
   if (!isInAttackRange && (!data.lastAttackTime || now - data.lastAttackTime > 2000)) {
     const direction = targetPos.sub(monster.position).normalize();
     data.direction.copy(direction);
-    const movement = data.direction.clone().multiplyScalar(data.speed * 3);
+    const chaseSpeed = data.chaseSpeed ?? (data.speed ?? 0.025) * 3;
+    const movement = data.direction.clone().multiplyScalar(chaseSpeed);
     const vel = body.linvel();
     body.setLinvel({ x: movement.x, y: vel.y, z: movement.z }, true);
     const angle = Math.atan2(data.direction.x, data.direction.z);


### PR DESCRIPTION
## Summary
- increase the monster's configured wander and chase speeds so its movement no longer feels like slow motion
- update the monster behaviour logic to use the new wander and chase speed properties with sensible fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97bf8248483259153745e5026cb14