### PR TITLE
Speed up monster animations

### DIFF
--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -5,6 +5,10 @@ export function switchMonsterAnimation(monster, newName) {
   if (newName === currentAction || !actions[newName]) return;
 
   const nextAction = actions[newName];
+  const animationSpeeds = monster.userData.animationSpeeds || {};
+  const defaultAnimationSpeed = monster.userData.defaultAnimationSpeed ?? 1;
+  const nextTimeScale = animationSpeeds[newName] ?? defaultAnimationSpeed;
+  nextAction.setEffectiveTimeScale(nextTimeScale);
   nextAction.reset();
 
   // Stop looping for death animation

--- a/models/monsterModel.js
+++ b/models/monsterModel.js
@@ -19,12 +19,21 @@ export function loadMonsterModel(scene, callback) {
           model.position.y += config.yOffset ?? 0;
           scene.add(model);
 
+          const defaultAnimationSpeed = config.animationSpeed ?? 1.6;
+          const perAnimationSpeeds = config.animationSpeeds ?? {};
+
           const mixer = new THREE.AnimationMixer(model);
           const actions = {};
           gltf.animations.forEach((clip) => {
             const name = clip.name.replace("CharacterArmature|", "");
-            actions[name] = mixer.clipAction(clip);
+            const action = mixer.clipAction(clip);
+            const timeScale = perAnimationSpeeds[name] ?? defaultAnimationSpeed;
+            action.setEffectiveTimeScale(timeScale);
+            actions[name] = action;
           });
+
+          model.userData.defaultAnimationSpeed = defaultAnimationSpeed;
+          model.userData.animationSpeeds = perAnimationSpeeds;
 
           callback({ model, mixer, actions });
         },

--- a/public/models/Orc.json
+++ b/public/models/Orc.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.5,
-  "yOffset": 0
+  "yOffset": 0,
+  "animationSpeed": 1.75
 }


### PR DESCRIPTION
## Summary
- apply configurable time scaling when loading monster animations
- respect the configured speeds when switching monster animation states
- update the default orc configuration with a faster animation speed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d97ead6ae88325abe04d77c3c34829