### PR TITLE
Fix monster update timing by reusing frame delta

### DIFF
--- a/app.js
+++ b/app.js
@@ -677,7 +677,8 @@ async function main() {
 
     // --- RAPIER FIXED-STEP & SYNC ---
     // Accumulate variable rAF time into fixed physics steps
-    physicsAccumulator += clock.getDelta();
+    const frameDelta = clock.getDelta();
+    physicsAccumulator += frameDelta;
     while (physicsAccumulator >= FIXED_DT) {
       applyGlobalGravity(rapierWorld, window.moon);
       applyWaveForces();
@@ -778,17 +779,17 @@ async function main() {
       showGameOver();
     }
 
-    const delta = mixerClock.getDelta();
+    const mixerDelta = mixerClock.getDelta();
     // Update visible waves and spawn new ones less frequently
-    updateWaves(delta);
-    nextWaveIn -= delta;
+    updateWaves(mixerDelta);
+    nextWaveIn -= mixerDelta;
     if (nextWaveIn <= 0) {
       spawnOceanWave();
       scheduleNextWave();
     }
 
     Object.values(otherPlayers).forEach(p => {
-      p.model.userData.mixer?.update(delta);
+      p.model.userData.mixer?.update(mixerDelta);
     });
 
     rowBoat.update();
@@ -840,7 +841,7 @@ async function main() {
       otherPlayers,
       multiplayer,
       monster,
-      clock
+      delta: frameDelta
     });
 
     updateMeleeAttacks({ playerModel, otherPlayers, monster, audioManager });

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -26,11 +26,13 @@ export function switchMonsterAnimation(monster, newName) {
 }
 
 
-export function updateMonster(monster, clock, playerModel, otherPlayers) {
+export function updateMonster(monster, deltaTime, playerModel, otherPlayers) {
   const now = Date.now();
   const data = monster.userData;
   const body = data.rb;
   if (!body) return;
+
+  const delta = Number.isFinite(deltaTime) ? deltaTime : 0;
 
   // 🧠 Handle monster death state
   if (window.monsterHealth <= 0) {
@@ -40,7 +42,6 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
     }
 
     // Continue updating the mixer so animation plays
-    const delta = clock.getDelta();
     if (data.mixer) data.mixer.update(delta);
 
     return; // ⛔ Stop further behavior logic (walking, attacking, etc.)
@@ -48,7 +49,6 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
 
   // Early return if reacting to a hit
   if (monster.userData.hitReacting) {
-    const delta = clock.getDelta();
     if (monster.userData.mixer) {
       monster.userData.mixer.update(delta);
     }
@@ -57,8 +57,6 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
 
   // 🕊️ Friendly mode: wander around without attacking players
   if (data.mode === "friendly") {
-    const delta = clock.getDelta();
-
     // Change direction every few seconds to simulate wandering
     if (now - data.lastDirectionChange > 2000) {
       data.direction = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
@@ -132,7 +130,6 @@ export function updateMonster(monster, clock, playerModel, otherPlayers) {
     }
   }
 
-  const delta = clock.getDelta();
   if (data.mixer) {
     data.mixer.update(delta);
   }

--- a/projectiles.js
+++ b/projectiles.js
@@ -42,7 +42,7 @@ export function updateProjectiles({
   playerModel,
   multiplayer,
   monster,
-  clock
+  delta
 }) {
   const removeProjectile = (index) => {
     const p = projectiles[index];
@@ -172,7 +172,7 @@ export function updateProjectiles({
   }
 
   if (multiplayer?.isHost && monster) {
-    updateMonster(monster, clock, playerModel, otherPlayers); // pass in new args
+    updateMonster(monster, delta, playerModel, otherPlayers);
     multiplayer.send({
       type: "monster",
       x: monster.position.x,


### PR DESCRIPTION
## Summary
- reuse the per-frame delta from the main clock when stepping physics and driving monster behavior so animations no longer slow down
- update the monster update helper and projectile logic to accept the shared delta time and keep other mixers on their own clock

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d98616184083258910a37e3276ee13