### PR TITLE
Fix remote player altitude desync

### DIFF
--- a/app.js
+++ b/app.js
@@ -502,7 +502,9 @@ async function main() {
       player.model.position.z = data.z;
 
       // Adjust vertical placement against local terrain height
-      const terrainY = 0;
+      const terrainY = (Number.isFinite(data.x) && Number.isFinite(data.z))
+        ? getTerrainHeight(data.x, data.z)
+        : 0;
       const targetY = Math.max(data.y ?? terrainY, terrainY);
       player.model.position.y = targetY;
 


### PR DESCRIPTION
## Summary
- sample remote player terrain height when processing presence updates
- clamp remote player Y positions against the sampled terrain height to prevent floating or sinking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db27d505848325a5b900e111e46e72