### PR TITLE
Fix remote player height desync

### DIFF
--- a/app.js
+++ b/app.js
@@ -505,8 +505,8 @@ async function main() {
       const terrainY = (Number.isFinite(data.x) && Number.isFinite(data.z))
         ? getTerrainHeight(data.x, data.z)
         : 0;
-      const targetY = Math.max(data.y ?? terrainY, terrainY);
-      player.model.position.y = targetY;
+      const hasAuthoritativeY = Number.isFinite(data.y);
+      player.model.position.y = hasAuthoritativeY ? data.y : terrainY;
 
       player.model.rotation.y = data.rotation;
       const moon = window.moon;


### PR DESCRIPTION
## Summary
- stop clamping remote player height to the local terrain sample
- trust the authoritative y value sent over presence updates so players stay aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db2a32c86c8325a824df04096416d1