### PR TITLE
Synchronize props and monster state via host-managed updates

### DIFF
--- a/projectiles.js
+++ b/projectiles.js
@@ -177,12 +177,6 @@ export function updateProjectiles({
 
   if (multiplayer?.isHost && monster) {
     updateMonster(monster, delta, playerModel, otherPlayers);
-    multiplayer.send({
-      type: "monster",
-      x: monster.position.x,
-      y: monster.position.y,
-      z: monster.position.z
-    });
   }
 
 }

--- a/surfboard.js
+++ b/surfboard.js
@@ -109,6 +109,10 @@ export class Surfboard {
       }
 
     } else {
+      const lastNetwork = this.mesh?.userData?.lastNetworkUpdate || 0;
+      if (performance.now() - lastNetwork < 200) {
+        return;
+      }
       const t = this.mesh.position;
       const waterDepth = getWaterDepth(t.x, t.z);
       const onWater = waterDepth > 0;


### PR DESCRIPTION
## Summary
- add host tracking utilities in the PeerJS wrapper so we can react to host handoff events and send direct peer messages
- introduce a networked entity manager in app.js that registers props and the monster, relays control updates to the host, and broadcasts authoritative state snapshots (including on host change)
- update surfboard handling and projectile logic to rely on the centralized host broadcast instead of per-frame direct sends

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2ca3896083258d1ae4b3b07eb774