### PR TITLE
Allow switching character without reloading the game

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -116,7 +116,27 @@ export class PlayerControls {
     this.lastHasGun = null;
     this.updateAmmoUI(window.iceGun?.holder === this);
   }
-  
+
+  setPlayerModel(newModel) {
+    if (this.parachute && this.playerModel && this.parachute.parent === this.playerModel) {
+      this.playerModel.remove(this.parachute);
+    }
+
+    this.playerModel = newModel;
+
+    if (this.parachute && this.playerModel) {
+      this.playerModel.add(this.parachute);
+    }
+
+    if (this.playerModel) {
+      if (this.body && typeof this.body.translation === 'function') {
+        const t = this.body.translation();
+        this.playerModel.position.set(t.x, t.y, t.z);
+      }
+      this.lastPosition.copy(this.playerModel.position);
+    }
+  }
+
   initializeControls() {
     if (this.isMobile) {
       this.initializeMobileControls();


### PR DESCRIPTION
## Summary
- load the selected character model in place and remove the full page reload when saving settings
- keep the active player label up to date and wire the new model into existing player controls
- add a helper on player controls to update their tracked model while preserving attachments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db2f9918dc8325a6f91122f7340d4b