### PR TITLE
Improve mobile controls and interaction prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,9 @@
     <span id="ammo-count">0</span>
   </div>
   <div id="action-buttons">
-    <button id="voice-button" class="action-button">Unmute</button>
-    <button id="talk-button" class="action-button">🎤</button>
+    <button id="mobile-action-toggle" class="action-button mobile-only" aria-expanded="false" aria-label="Toggle actions">⋯</button>
+    <button id="voice-button" class="action-button mobile-action">Unmute</button>
+    <button id="talk-button" class="action-button mobile-action">🎤</button>
   </div>
   
   <!-- Settings Button -->

--- a/styles.css
+++ b/styles.css
@@ -148,6 +148,10 @@ body {
   cursor: pointer;
 }
 
+.mobile-only {
+  display: none;
+}
+
 #camera-controls {
   position: fixed;
   bottom: 10px;
@@ -406,6 +410,63 @@ body {
 
 
 
+
+@media (pointer: coarse) {
+  #action-buttons {
+    bottom: 16px;
+    left: 16px;
+    gap: 6px;
+  }
+
+  #action-buttons .action-button {
+    width: 52px;
+    height: 52px;
+    font-size: 14px;
+  }
+
+  #action-buttons .mobile-action {
+    display: none;
+  }
+
+  #action-buttons.mobile-expanded .mobile-action {
+    display: flex;
+  }
+
+  #mobile-action-toggle {
+    display: flex;
+    font-size: 24px;
+    padding-bottom: 4px;
+  }
+
+  #mobile-action-toggle[aria-expanded="true"] {
+    background-color: rgba(255, 255, 255, 0.7);
+  }
+
+  .mobile-only {
+    display: flex;
+  }
+
+  #joystick-container {
+    width: 120px;
+    height: 120px;
+    bottom: 16px;
+    right: 16px;
+  }
+
+  #jump-button {
+    width: 70px;
+    height: 70px;
+    line-height: 70px;
+    font-size: 14px;
+    bottom: 140px;
+    right: 16px;
+  }
+
+  .interaction-tooltip.visible {
+    pointer-events: auto;
+    cursor: pointer;
+  }
+}
 
 @media (pointer: coarse) and (max-width: 768px),
        (pointer: coarse) and (max-height: 768px) {


### PR DESCRIPTION
## Summary
- hide the mobile action buttons behind a toggle and update sizing so controls take up less space
- shrink the virtual joystick and jump button for mobile layouts
- allow tapping the on-screen interaction prompt on mobile to perform the associated action

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df03c216c08325bd2a1e398e1a9939