### PR TITLE
Reduce kick impulse values for balanced ball physics

### DIFF
--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -8,7 +8,7 @@ const PLAYER_HALF_HEIGHT = 0.6;
 const PLAYER_RADIUS = 0.3;
 const KICK_RANGE = 1.8;
 const KICK_COOLDOWN = 1200;
-const KICK_IMPULSE = 20;
+const KICK_IMPULSE = 0.667;
 const GROUND_OFFSET = PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
 
 export class AIPlayer {

--- a/melee.js
+++ b/melee.js
@@ -70,7 +70,7 @@ export function updateMeleeAttacks({ playerModel, otherPlayers, monster, audioMa
               .normalize();
             dir.y = Math.max(dir.y, 0.2);
             dir.normalize();
-            window.soccerBall.applyImpulse({ x: dir.x * 0.2, y: dir.y * 0.2, z: dir.z * 0.2 });
+            window.soccerBall.applyImpulse({ x: dir.x * 0.00667, y: dir.y * 0.00667, z: dir.z * 0.00667 });
           }
         }
       }


### PR DESCRIPTION
## Summary
Adjusted kick impulse values across the codebase to reduce the force applied to the soccer ball when kicked by both AI players and melee attacks. This change appears to be a physics balancing adjustment to make ball movement more controlled and realistic.

## Key Changes
- **aiPlayer.js**: Reduced `KICK_IMPULSE` constant from `20` to `0.667` (~96.7% reduction)
- **melee.js**: Reduced melee attack impulse multiplier from `0.2` to `0.00667` (~96.7% reduction) when applying force to the soccer ball

## Implementation Details
Both changes maintain the same proportional reduction ratio, suggesting this is a coordinated physics tuning pass. The impulse values are now significantly lower, which should result in:
- More controlled ball movement during kicks
- Better gameplay balance between player actions and ball physics
- Potentially improved responsiveness to directional input (the direction normalization logic remains unchanged)

https://claude.ai/code/session_01STtQc2QUnDxBquQbGMJE6g