### PR TITLE
Improve set piece spawn positioning and ball escape handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,23 +412,47 @@ async function main() {
     soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
     soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
 
-    // Teleport the taking player into the zone
+    // Teleport the taking player into the zone, offset from the ball so they
+    // don't spawn on top of it.
     const spBody = teamTaking === 'home' ? playerControls?.body : aiPlayer?.body;
     if (spBody) {
       const sy = 1.5; // drops onto ground via physics; ground collider top is Y=0
-      spBody.setTranslation({ x: ballFixedPos.x, y: sy, z: ballFixedPos.z }, true);
+
+      // Compute spawn position: offset from ball toward the interior of the zone
+      // so the player is inside the zone but not occupying the ball's spot.
+      const zoneCx = (zone.minX + zone.maxX) / 2;
+      const zoneCz = (zone.minZ + zone.maxZ) / 2;
+      let odx = zoneCx - ballFixedPos.x;
+      let odz = zoneCz - ballFixedPos.z;
+      const olen = Math.sqrt(odx * odx + odz * odz);
+      const SPAWN_OFFSET = 1.5;
+      let spawnX, spawnZ;
+      if (olen < 0.1) {
+        // Ball is at zone centre (e.g. throw-in); offset in Z within the zone
+        spawnX = ballFixedPos.x;
+        spawnZ = ballFixedPos.z + SPAWN_OFFSET;
+      } else {
+        spawnX = ballFixedPos.x + (odx / olen) * SPAWN_OFFSET;
+        spawnZ = ballFixedPos.z + (odz / olen) * SPAWN_OFFSET;
+      }
+
+      spBody.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
       spBody.setLinvel({ x: 0, y: 0, z: 0 }, true);
       spBody.setAngvel({ x: 0, y: 0, z: 0 }, true);
 
       // Sync the Three.js model and PlayerControls state for the local player
       if (teamTaking === 'home' && playerModel && playerControls) {
-        playerModel.position.set(ballFixedPos.x, sy, ballFixedPos.z);
-        playerControls.playerX = ballFixedPos.x;
+        playerModel.position.set(spawnX, sy, spawnZ);
+        playerControls.playerX = spawnX;
         playerControls.playerY = sy;
-        playerControls.playerZ = ballFixedPos.z;
-        playerControls.lastPosition.set(ballFixedPos.x, sy, ballFixedPos.z);
+        playerControls.playerZ = spawnZ;
+        playerControls.lastPosition.set(spawnX, sy, spawnZ);
       }
     }
+
+    // Record the set piece taker as the current last-toucher so that if they
+    // immediately kick the ball back out, the next set piece goes to the other team.
+    soccerBall.lastTouchedTeam = teamTaking;
 
     setPieceManager.trigger(type, teamTaking, ballFixedPos, zone);
   }

--- a/setPiece.js
+++ b/setPiece.js
@@ -83,9 +83,16 @@ export class SetPieceManager {
         // Also end if ball has gone very far out (fallback)
         const farOut = Math.abs(bp.x) > FIELD_HALF_X + 8 || Math.abs(bp.z) > FIELD_HALF_Z + 8;
 
-        if (inBounds || farOut) {
+        if (inBounds) {
           this.clear();
           return true;
+        }
+        if (farOut) {
+          // Ball escaped too far; snap it back to the set piece spot
+          soccerBall.body.setTranslation(a.ballFixedPos, true);
+          soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+          soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+          a.ballLocked = true;
         }
       }
     }

--- a/soccerBall.js
+++ b/soccerBall.js
@@ -105,7 +105,10 @@ export class SoccerBall {
     const dist = Math.sqrt(distSq);
     if (dist >= minDist || dist < 1e-4) return;
 
-    if (team) this.lastTouchedTeam = team;
+    const playerSpeed = Math.sqrt(
+      playerVel.x * playerVel.x + playerVel.y * playerVel.y + playerVel.z * playerVel.z
+    );
+    if (team && playerSpeed > 0.5) this.lastTouchedTeam = team;
 
     const nx = dx / dist;
     const ny = dy / dist;


### PR DESCRIPTION
## Summary
This PR improves the set piece mechanics by fixing player spawn positioning during set pieces and adding better handling for balls that escape the play area.

## Key Changes

- **Player spawn offset from ball**: When a set piece is triggered, the taking player now spawns offset from the ball toward the zone center, preventing them from spawning directly on top of the ball. The offset distance is 1.5 units, with special handling when the ball is at the zone center (e.g., throw-ins).

- **Ball escape recovery**: When a ball travels too far out of bounds during a set piece (beyond FIELD_HALF_X + 8 or FIELD_HALF_Z + 8), it is now snapped back to the set piece position with velocity reset, rather than simply ending the set piece.

- **Set piece taker tracking**: The set piece taker is now recorded as the last toucher of the ball, ensuring that if they immediately kick the ball back out, the next set piece goes to the opposing team.

- **Touch detection threshold**: Added a minimum player speed threshold (0.5 units/sec) for registering ball touches, preventing accidental touch registrations from slow-moving or stationary players.

## Implementation Details

- The spawn position calculation uses vector math to offset the player toward the zone center, with a fallback for edge cases where the ball is already at the zone center.
- All Three.js model positions and PlayerControls state are synchronized with the new spawn position.
- The ball escape handling preserves the set piece state while resetting the ball, allowing play to continue from the original position.

https://claude.ai/code/session_01AfR2Yda1Si6nCGpbuhp3kn