### PR TITLE
Fix set piece player spawn positioning and ball contact tracking

### DIFF
--- a/app.js
+++ b/app.js
@@ -412,21 +412,36 @@ async function main() {
     soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
     soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
 
-    // Teleport the taking player into the zone
+    // Teleport the taking player into the zone, offset from the ball so they
+    // don't start overlapping it (which would corrupt lastTouchedTeam tracking).
     const spBody = teamTaking === 'home' ? playerControls?.body : aiPlayer?.body;
     if (spBody) {
       const sy = 1.5; // drops onto ground via physics; ground collider top is Y=0
-      spBody.setTranslation({ x: ballFixedPos.x, y: sy, z: ballFixedPos.z }, true);
+      let spawnX = ballFixedPos.x;
+      let spawnZ = ballFixedPos.z;
+      const OFFSET = 1.5;
+      if (type === 'throwIn') {
+        // Player stands just outside the sideline, offset in X away from field
+        spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
+      } else if (type === 'cornerKick') {
+        // Player stands inside the corner zone, away from the corner flag
+        spawnX = ballFixedPos.x - Math.sign(ballFixedPos.x) * OFFSET;
+        spawnZ = ballFixedPos.z - Math.sign(ballFixedPos.z) * OFFSET;
+      } else if (type === 'goalKick') {
+        // Player stands behind the ball (toward their own goal line)
+        spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
+      }
+      spBody.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
       spBody.setLinvel({ x: 0, y: 0, z: 0 }, true);
       spBody.setAngvel({ x: 0, y: 0, z: 0 }, true);
 
       // Sync the Three.js model and PlayerControls state for the local player
       if (teamTaking === 'home' && playerModel && playerControls) {
-        playerModel.position.set(ballFixedPos.x, sy, ballFixedPos.z);
-        playerControls.playerX = ballFixedPos.x;
+        playerModel.position.set(spawnX, sy, spawnZ);
+        playerControls.playerX = spawnX;
         playerControls.playerY = sy;
-        playerControls.playerZ = ballFixedPos.z;
-        playerControls.lastPosition.set(ballFixedPos.x, sy, ballFixedPos.z);
+        playerControls.playerZ = spawnZ;
+        playerControls.lastPosition.set(spawnX, sy, spawnZ);
       }
     }
 
@@ -1129,13 +1144,18 @@ async function main() {
 
     soccerBall?.update();
     if (soccerBall?.body) {
+      // During the lock phase of a set piece the set piece player is placed right
+      // next to the ball. Suppress lastTouchedTeam updates until the lock releases
+      // so that the spawn teleport doesn't corrupt who last touched the ball.
+      const spLocked = setPieceManager?.active?.ballLocked ?? false;
+      const spTeam   = setPieceManager?.active?.teamTaking;
       if (playerControls.body) {
         soccerBall.resolvePlayerContact(
           playerControls.body.translation(),
           playerControls.body.linvel(),
           0.3,
           0.6,
-          'home'
+          spLocked && spTeam === 'home' ? null : 'home'
         );
       }
       if (aiPlayer?.body) {
@@ -1144,7 +1164,7 @@ async function main() {
           aiPlayer.body.linvel(),
           0.3,
           0.6,
-          'away'
+          spLocked && spTeam === 'away' ? null : 'away'
         );
       }
     }

--- a/setPiece.js
+++ b/setPiece.js
@@ -80,10 +80,17 @@ export class SetPieceManager {
       const bp = soccerBall.getPosition();
       if (bp) {
         const inBounds = Math.abs(bp.x) < FIELD_HALF_X && Math.abs(bp.z) < FIELD_HALF_Z;
-        // Also end if ball has gone very far out (fallback)
+        // If ball escapes far outside the field during the set piece, reset it
+        // back to the set piece spot rather than letting it disappear off the pitch.
         const farOut = Math.abs(bp.x) > FIELD_HALF_X + 8 || Math.abs(bp.z) > FIELD_HALF_Z + 8;
 
-        if (inBounds || farOut) {
+        if (farOut) {
+          soccerBall.body.setTranslation(a.ballFixedPos, true);
+          soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+          soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+          a.ballLocked = true;
+          a.startTime = performance.now();
+        } else if (inBounds) {
           this.clear();
           return true;
         }


### PR DESCRIPTION
## Summary
This PR fixes issues with set piece execution by improving player spawn positioning relative to the ball and preventing incorrect ball contact tracking during the spawn phase.

## Key Changes

- **Improved player spawn positioning for set pieces**: Players are now spawned at offset positions based on the set piece type rather than directly on the ball:
  - **Throw-in**: Player spawns outside the sideline, offset in X direction away from field
  - **Corner kick**: Player spawns inside corner zone, offset away from corner flag in both X and Z
  - **Goal kick**: Player spawns behind the ball toward their own goal line

- **Suppressed lastTouchedTeam updates during spawn lock**: Added logic to prevent the spawn teleport from corrupting ball contact tracking by passing `null` as the team parameter to `resolvePlayerContact()` when a set piece is locked and the player is being positioned.

- **Improved ball escape handling**: When the ball escapes far outside the field during a set piece, it's now reset to the set piece position and the lock is maintained, rather than allowing it to disappear.

## Implementation Details

- Added `OFFSET` constant (1.5 units) for consistent spawn positioning
- Spawn position calculation uses `Math.sign()` to determine direction based on ball location
- Set piece lock state (`ballLocked`) is checked via `setPieceManager?.active?.ballLocked` to gate contact tracking
- Player model and physics state are kept in sync using the calculated spawn coordinates

https://claude.ai/code/session_0177LEWf4TWM2MKQLwiwEnf8