### PR TITLE
Add team colors to soccer field and player models

### DIFF
--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -19,7 +19,7 @@ export class AIPlayer {
     this.rapierWorld = rapierWorld;
     this.targetGoalZ = targetGoalZ;
 
-    this.character = new PlayerCharacter('Computer', '/models/old_man.fbx');
+    this.character = new PlayerCharacter('Computer', '/models/old_man.fbx', 0xff3322);
     this.model = this.character.model;
     scene.add(this.model);
     document.body.appendChild(this.character.nameLabel);

--- a/app.js
+++ b/app.js
@@ -343,12 +343,12 @@ async function main() {
   const SCORE_FIELD_HALF = 50;
 
   const scoreEl = document.createElement('div');
-  scoreEl.style.cssText = 'position:fixed;top:16px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.6);color:#fff;font-size:28px;font-weight:bold;padding:8px 28px;border-radius:10px;z-index:200;font-family:sans-serif;pointer-events:none;letter-spacing:4px;';
-  scoreEl.textContent = '0 - 0';
+  scoreEl.style.cssText = 'position:fixed;top:16px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.6);font-size:28px;font-weight:bold;padding:8px 28px;border-radius:10px;z-index:200;font-family:sans-serif;pointer-events:none;letter-spacing:4px;';
+  scoreEl.innerHTML = '<span style="color:#3399ff">0</span> <span style="color:#fff">-</span> <span style="color:#ff3322">0</span>';
   document.body.appendChild(scoreEl);
 
   function updateScoreUI() {
-    scoreEl.textContent = `${score.home} - ${score.away}`;
+    scoreEl.innerHTML = `<span style="color:#3399ff">${score.home}</span> <span style="color:#fff">-</span> <span style="color:#ff3322">${score.away}</span>`;
   }
 
   const SCORE_FIELD_X_HALF = 30; // field is 60 wide
@@ -512,7 +512,7 @@ async function main() {
 
 
 
-  let player = new PlayerCharacter(playerName, characterModel);
+  let player = new PlayerCharacter(playerName, characterModel, 0x3399ff);
   let playerModel = player.model;
   scene.add(playerModel);
   document.body.appendChild(player.nameLabel);
@@ -791,7 +791,7 @@ async function main() {
       previousModel.remove(playerControls.parachute);
     }
 
-    const newPlayer = new PlayerCharacter(playerName, newModelPath);
+    const newPlayer = new PlayerCharacter(playerName, newModelPath, 0x3399ff);
     const newModel = newPlayer.model;
     newModel.position.copy(currentPosition);
     newModel.rotation.copy(currentRotation);

--- a/characters/PlayerCharacter.js
+++ b/characters/PlayerCharacter.js
@@ -4,7 +4,7 @@ import { createPlayerModel } from "../models/playerModel.js";
 import * as THREE from "three";
 
 export class PlayerCharacter extends CharacterBase {
-  constructor(username, modelPath) {
+  constructor(username, modelPath, teamColor = null) {
     const { model, nameLabel } = createPlayerModel(
       THREE,
       username,
@@ -12,7 +12,8 @@ export class PlayerCharacter extends CharacterBase {
         this.mixer = mixer;
         this.actions = actions;
       },
-      modelPath
+      modelPath,
+      teamColor
     );
     super(model);
     this.nameLabel = nameLabel;

--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -125,7 +125,8 @@ export function createPlayerModel(
   THREE,
   username,
   onLoad,
-  modelPath = '/models/old_man.fbx'
+  modelPath = '/models/old_man.fbx',
+  teamColor = null
 ) {
   const playerGroup = new THREE.Group();
   const loader = new FBXLoader();
@@ -207,6 +208,18 @@ export function createPlayerModel(
             if (o.isSkinnedMesh || o.isMesh) o.frustumCulled = false;
             if (o.material?.skinning === true) o.material.skinning = true;
           });
+
+          if (teamColor !== null) {
+            const tint = new THREE.Color(teamColor);
+            model.traverse(o => {
+              if ((o.isMesh || o.isSkinnedMesh) && o.material) {
+                const mats = Array.isArray(o.material) ? o.material : [o.material];
+                for (const mat of mats) {
+                  if (mat.color) mat.color.multiply(tint);
+                }
+              }
+            });
+          }
 
 
           // Scale and center the model so it rotates around its midpoint

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -122,8 +122,8 @@ const GOAL_WIDTH = 10;
 const GOAL_HEIGHT = 3;
 const GOAL_DEPTH = 2;
 
-function addGoal(scene, zSign, rapierWorld) {
-  const postMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.4, metalness: 0.3 });
+function addGoal(scene, zSign, rapierWorld, color = 0xffffff) {
+  const postMat = new THREE.MeshStandardMaterial({ color, roughness: 0.4, metalness: 0.3 });
   const postR = 0.12;
   const halfGoal = GOAL_WIDTH / 2;
   const zPos = zSign * (FIELD_LENGTH / 2);
@@ -175,7 +175,7 @@ function addGoal(scene, zSign, rapierWorld) {
   }
 
   // Net (back plane)
-  const netMat = new THREE.MeshStandardMaterial({ color: 0xffffff, transparent: true, opacity: 0.25, side: THREE.DoubleSide });
+  const netMat = new THREE.MeshStandardMaterial({ color, transparent: true, opacity: 0.25, side: THREE.DoubleSide });
   const net = new THREE.Mesh(
     new THREE.PlaneGeometry(GOAL_WIDTH, GOAL_HEIGHT),
     netMat
@@ -185,8 +185,8 @@ function addGoal(scene, zSign, rapierWorld) {
   scene.add(net);
 }
 
-function addFieldLine(scene, x, z, width, depth, y = 0.01) {
-  const lineMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.8 });
+function addFieldLine(scene, x, z, width, depth, y = 0.01, color = 0xffffff) {
+  const lineMat = new THREE.MeshStandardMaterial({ color, roughness: 0.8 });
   const mesh = new THREE.Mesh(new THREE.PlaneGeometry(width, depth), lineMat);
   mesh.rotation.x = -Math.PI / 2;
   mesh.position.set(x, y, z);
@@ -270,17 +270,20 @@ export function generateSoccerField(scene, rapierWorld) {
   scene.add(surround);
 
   const LT = 0.35; // line thickness
+  const BLUE = 0x3399ff;
+  const RED  = 0xff3322;
 
-  // Touchlines (long sides)
-  addFieldLine(scene, 0, 0, LT, FIELD_LENGTH);
-  addFieldLine(scene, FIELD_WIDTH / 2, 0, LT, FIELD_LENGTH);
-  addFieldLine(scene, -FIELD_WIDTH / 2, 0, LT, FIELD_LENGTH);
+  // Touchlines (long sides) — split at halfway: blue on home (-Z) half, red on away (+Z) half
+  for (const xPos of [0, FIELD_WIDTH / 2, -FIELD_WIDTH / 2]) {
+    addFieldLine(scene, xPos, -FIELD_LENGTH / 4, LT, FIELD_LENGTH / 2, 0.01, BLUE);
+    addFieldLine(scene, xPos,  FIELD_LENGTH / 4, LT, FIELD_LENGTH / 2, 0.01, RED);
+  }
 
   // Goal lines
-  addFieldLine(scene, 0, FIELD_LENGTH / 2, FIELD_WIDTH, LT);
-  addFieldLine(scene, 0, -FIELD_LENGTH / 2, FIELD_WIDTH, LT);
+  addFieldLine(scene, 0,  FIELD_LENGTH / 2, FIELD_WIDTH, LT, 0.01, RED);   // away (+Z) side
+  addFieldLine(scene, 0, -FIELD_LENGTH / 2, FIELD_WIDTH, LT, 0.01, BLUE);  // home (-Z) side
 
-  // Halfway line
+  // Halfway line (neutral white)
   addFieldLine(scene, 0, 0, FIELD_WIDTH, LT);
 
   // Centre circle (approximated with ring segments)
@@ -308,19 +311,19 @@ export function generateSoccerField(scene, rapierWorld) {
   spot.position.set(0, 0.01, 0);
   scene.add(spot);
 
-  // Penalty areas
+  // Penalty areas — colored to match team side
   const paWidth = 40.32, paDepth = 16.5;
   for (const zSign of [-1, 1]) {
+    const paColor = zSign > 0 ? RED : BLUE;
     const zCenter = zSign * (FIELD_LENGTH / 2 - paDepth / 2);
-    // outline (4 sides)
-    addFieldLine(scene, 0, zSign * FIELD_LENGTH / 2 - zSign * paDepth, paWidth, LT);
-    addFieldLine(scene, paWidth / 2, zCenter, LT, paDepth);
-    addFieldLine(scene, -paWidth / 2, zCenter, LT, paDepth);
+    addFieldLine(scene, 0, zSign * FIELD_LENGTH / 2 - zSign * paDepth, paWidth, LT, 0.01, paColor);
+    addFieldLine(scene, paWidth / 2, zCenter, LT, paDepth, 0.01, paColor);
+    addFieldLine(scene, -paWidth / 2, zCenter, LT, paDepth, 0.01, paColor);
   }
 
-  // Goals
-  addGoal(scene, 1, rapierWorld);
-  addGoal(scene, -1, rapierWorld);
+  // Goals — blue for home (-Z), red for away (+Z)
+  addGoal(scene,  1, rapierWorld, RED);
+  addGoal(scene, -1, rapierWorld, BLUE);
 
   // Stands (4 sides)
   const standGap = 4;


### PR DESCRIPTION
## Summary
This PR implements team-based color theming for the soccer game, introducing blue for the home team and red for the away team across the field markings, goals, and player models.

## Key Changes

- **Field Markings**: Updated field lines to use team colors:
  - Touchlines (long sides) split at halfway: blue on home (-Z) half, red on away (+Z) half
  - Goal lines colored to match their respective team side
  - Penalty areas outlined in their team color
  - Halfway line remains neutral white

- **Goals**: Added `color` parameter to `addGoal()` function to support team-colored goal posts and nets
  - Home goal (-Z): blue
  - Away goal (+Z): red

- **Player Models**: Extended `createPlayerModel()` and `PlayerCharacter` to accept optional `teamColor` parameter
  - Applies color tinting to player model materials when team color is provided
  - Home player (human): blue tint
  - Away player (AI): red tint

- **Score Display**: Enhanced UI to show team colors in the score display
  - Home score in blue (#3399ff)
  - Away score in red (#ff3322)
  - Separator dash remains white

## Implementation Details

- Added `BLUE = 0x3399ff` and `RED = 0xff3322` color constants in world generation
- Color parameter defaults to white (0xffffff) for backward compatibility
- Player model tinting uses `Color.multiply()` to apply color to existing materials
- All field line calls updated to pass explicit y-position (0.01) for consistency

https://claude.ai/code/session_01JYMSzj3nBmGsUQ3jWmn61v