### PR TITLE
Fix set piece zones and player spawning for corner kicks

### DIFF
--- a/app.js
+++ b/app.js
@@ -419,9 +419,9 @@ async function main() {
         // Player stands just outside the sideline, offset in X away from field
         spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
       } else if (type === 'cornerKick') {
-        // Player stands inside the corner zone, away from the corner flag
-        spawnX = ballFixedPos.x - Math.sign(ballFixedPos.x) * OFFSET;
-        spawnZ = ballFixedPos.z - Math.sign(ballFixedPos.z) * OFFSET;
+        // Player stands outside the field in the corner zone
+        spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
+        spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
       } else if (type === 'goalKick') {
         // Player stands behind the ball (toward their own goal line)
         spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;

--- a/melee.js
+++ b/melee.js
@@ -49,6 +49,8 @@ export function updateMeleeAttacks({ playerModel, otherPlayers, audioManager }) 
           const dist = attacker.model.position.distanceTo(ballVec);
           if (dist <= cfg.range + 0.3) {
             hit = true;
+            const team = attacker.id === 'local' ? 'home' : 'away';
+            window.soccerBall.lastTouchedTeam = team;
             const dir = new THREE.Vector3()
               .subVectors(ballVec, attacker.model.position)
               .normalize();

--- a/setPiece.js
+++ b/setPiece.js
@@ -79,18 +79,17 @@ export class SetPieceManager {
       // Check end conditions after lock released
       const bp = soccerBall.getPosition();
       if (bp) {
-        const inBounds = Math.abs(bp.x) < FIELD_HALF_X && Math.abs(bp.z) < FIELD_HALF_Z;
-        // If ball escapes far outside the field during the set piece, reset it
-        // back to the set piece spot rather than letting it disappear off the pitch.
-        const farOut = Math.abs(bp.x) > FIELD_HALF_X + 8 || Math.abs(bp.z) > FIELD_HALF_Z + 8;
+        const inField = Math.abs(bp.x) < FIELD_HALF_X && Math.abs(bp.z) < FIELD_HALF_Z;
+        const inZone = bp.x >= a.zone.minX && bp.x <= a.zone.maxX &&
+                       bp.z >= a.zone.minZ && bp.z <= a.zone.maxZ;
 
-        if (farOut) {
+        if (!inZone && !inField) {
           soccerBall.body.setTranslation(a.ballFixedPos, true);
           soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
           soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
           a.ballLocked = true;
           a.startTime = performance.now();
-        } else if (inBounds) {
+        } else if (inField) {
           this.clear();
           return true;
         }
@@ -271,10 +270,11 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
     const clampedZ = Math.max(-FIELD_HALF_Z + 1, Math.min(FIELD_HALF_Z - 1, ballOutPos.z));
     const ballFixedPos = { x: sideX, y: fieldY, z: clampedZ };
 
-    const hw = 3; // half-width of zone
+    const hw = 3;
+    const xSign = Math.sign(sideX);
     const zone = {
-      minX: sideX - hw,
-      maxX: sideX + hw,
+      minX: xSign > 0 ? sideX : sideX - 2 * hw,
+      maxX: xSign > 0 ? sideX + 2 * hw : sideX,
       minZ: clampedZ - hw,
       maxZ: clampedZ + hw,
     };
@@ -298,13 +298,13 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
       const cornerZ = zSign * FIELD_HALF_Z;
       const ballFixedPos = { x: cornerX, y: fieldY, z: cornerZ };
 
-      // Zone hugs the corner, extending 3.5 units into the field on each axis
+      // Zone is outside the field; the corner of the zone sits on the field corner
       const extent = 3.5;
       const zone = {
-        minX: xSign > 0 ? cornerX - extent : cornerX,
-        maxX: xSign > 0 ? cornerX : cornerX + extent,
-        minZ: zSign > 0 ? cornerZ - extent : cornerZ,
-        maxZ: zSign > 0 ? cornerZ : cornerZ + extent,
+        minX: xSign > 0 ? cornerX : cornerX - extent,
+        maxX: xSign > 0 ? cornerX + extent : cornerX,
+        minZ: zSign > 0 ? cornerZ : cornerZ - extent,
+        maxZ: zSign > 0 ? cornerZ + extent : cornerZ,
       };
       return { type: 'cornerKick', teamTaking, ballFixedPos, zone };
     } else {


### PR DESCRIPTION
## Summary
This PR fixes the set piece zone boundaries and player spawning logic for corner kicks, and corrects the ball tracking for melee attacks.

## Key Changes

- **Set piece zone logic**: Changed from a "far out" boundary check to a more precise zone-based check. The ball now resets if it leaves both the field bounds AND the designated set piece zone, rather than just checking if it goes far outside the field.

- **Throw-in zone boundaries**: Updated the throw-in zone to extend 6 units (2 * hw) perpendicular to the sideline based on which side of the field the throw-in occurs, ensuring the zone is positioned correctly relative to the field edge.

- **Corner kick zone**: Inverted the zone boundary logic so the zone extends outside the field (away from the corner) rather than inside. The zone corner now sits exactly on the field corner, with the zone extending outward by 3.5 units on each axis.

- **Corner kick player spawning**: Changed player spawn position from inside the corner zone (away from corner flag) to outside the field in the corner zone, matching the updated zone geometry.

- **Melee attack ball tracking**: Added proper team assignment to the ball's `lastTouchedTeam` property when a melee attack hits the ball, ensuring correct set piece team assignment after a tackle.

## Implementation Details

The zone-based approach provides more flexible and accurate control over where the ball can be during set pieces, allowing different zone shapes for different set piece types (throw-ins vs corner kicks) while maintaining consistent reset behavior.

https://claude.ai/code/session_01V3BYj9mZ2x9VaBaCp5X6VB