### PR TITLE
Implement team-based multiplayer soccer with dynamic AI balancing

### DIFF
--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -14,12 +14,12 @@ const KICK_REGISTER_DELAY = 250;
 const GROUND_OFFSET = PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
 
 export class AIPlayer {
-  constructor(scene, rapierWorld, { spawnZ = 35, targetGoalZ = -50 } = {}) {
+  constructor(scene, rapierWorld, { spawnZ = 35, targetGoalZ = -50, color = 0xff3322 } = {}) {
     this.scene = scene;
     this.rapierWorld = rapierWorld;
     this.targetGoalZ = targetGoalZ;
 
-    this.character = new PlayerCharacter('Computer', '/models/old_man.fbx', 0xff3322);
+    this.character = new PlayerCharacter('Computer', '/models/old_man.fbx', color);
     this.model = this.character.model;
     scene.add(this.model);
     document.body.appendChild(this.character.nameLabel);

--- a/app.js
+++ b/app.js
@@ -161,8 +161,19 @@ async function main() {
       const remoteId = data.id || peerId;
       const desiredModel = data.model || DEFAULT_CHARACTER_MODEL;
 
+      // Determine this peer's team assignment
+      const isNewPeer = !(remoteId in playerTeams);
+      if (isNewPeer) {
+        // Store their declared team (null if not yet assigned).
+        // rebalanceTeams() will fill in nulls and broadcast final assignments.
+        playerTeams[remoteId] = data.team || null;
+      }
+
+      const assignedTeam = playerTeams[remoteId] ?? null;
       const existing = otherPlayers[remoteId];
-      if (!existing || existing.modelPath !== desiredModel) {
+      const teamChanged = existing && existing.team !== assignedTeam;
+
+      if (!existing || existing.modelPath !== desiredModel || teamChanged) {
         if (existing) {
           if (existing.model && existing.model.parent) {
             existing.model.parent.remove(existing.model);
@@ -172,7 +183,8 @@ async function main() {
           }
         }
 
-        const other = new PlayerCharacter(data.name, desiredModel);
+        const teamColor = assignedTeam === 'home' ? 0x3399ff : assignedTeam === 'away' ? 0xff3322 : null;
+        const other = new PlayerCharacter(data.name, desiredModel, teamColor);
         scene.add(other.model);
         document.body.appendChild(other.nameLabel);
         otherPlayers[remoteId] = {
@@ -180,13 +192,15 @@ async function main() {
           nameLabel: other.nameLabel,
           name: data.name,
           health: existing?.health ?? 100,
-          modelPath: desiredModel
+          modelPath: desiredModel,
+          team: assignedTeam
         };
       }
 
       const player = otherPlayers[remoteId];
       player.name = data.name;
       player.modelPath = desiredModel;
+      player.team = assignedTeam;
       if (player.nameLabel) {
         player.nameLabel.innerText = data.name;
       }
@@ -252,6 +266,36 @@ async function main() {
         list.appendChild(item);
       }
       conn.listItem.textContent = `Connected to ${data.name}`;
+      return;
+    }
+
+    if (data.type === 'teamAssignments') {
+      const myId = multiplayer?.getId?.();
+      Object.entries(data.assignments || {}).forEach(([pid, team]) => {
+        if (pid === myId) {
+          if (team !== localPlayerTeam) {
+            localPlayerTeam = team;
+            localTeamConfirmed = true;
+            const newColor = team === 'home' ? 0x3399ff : 0xff3322;
+            swapPlayerCharacter(characterModel, newColor);
+          } else {
+            localTeamConfirmed = true;
+          }
+        } else {
+          const oldTeam = playerTeams[pid];
+          playerTeams[pid] = team;
+          // Force model rebuild on next presence if team changed
+          if (otherPlayers[pid] && oldTeam !== team) {
+            otherPlayers[pid].team = null;
+          }
+        }
+      });
+
+      const newAiTeam = data.aiTeam ?? null;
+      if (newAiTeam !== aiTeam) {
+        if (newAiTeam === null) removeAI();
+        else spawnAI(newAiTeam);
+      }
       return;
     }
 
@@ -322,7 +366,29 @@ async function main() {
           requesterId: multiplayer.getId(),
           previousHostId
         });
+        // Becoming host after joining a room with existing players:
+        // reset team confirmation so rebalanceTeams can assign the correct team.
+        localTeamConfirmed = false;
       }
+      // Rebalance teams after a short delay to allow presences from all peers to arrive
+      setTimeout(rebalanceTeams, 600);
+    }
+  };
+
+  multiplayer.onPeerDisconnect = (peerId) => {
+    delete playerTeams[peerId];
+    if (otherPlayers[peerId]) {
+      if (otherPlayers[peerId].model?.parent)
+        otherPlayers[peerId].model.parent.remove(otherPlayers[peerId].model);
+      if (otherPlayers[peerId].nameLabel?.parentNode)
+        otherPlayers[peerId].nameLabel.parentNode.removeChild(otherPlayers[peerId].nameLabel);
+      delete otherPlayers[peerId];
+    }
+    const listItem = document.getElementById(`peer-${peerId}`);
+    if (listItem) listItem.remove();
+    if (multiplayer?.isHost) {
+      updateAIForBalance();
+      broadcastTeamAssignments();
     }
   };
   const audioManager = new AudioManager();
@@ -334,7 +400,13 @@ async function main() {
 
   let soccerBall;
   let aiPlayer;
+  let aiTeam = null;
   let setPieceManager;
+
+  // Team management: tracks which team each peer is on ('home' | 'away')
+  const playerTeams = {};
+  let localPlayerTeam = 'home';
+  let localTeamConfirmed = false;
 
   const score = { home: 0, away: 0 };
   let goalCooldown = 0;
@@ -412,7 +484,7 @@ async function main() {
 
     // Teleport the taking player into the zone, offset from the ball so they
     // don't start overlapping it (which would corrupt lastTouchedTeam tracking).
-    const spBody = teamTaking === 'home' ? playerControls?.body : aiPlayer?.body;
+    const spBody = getBodyForTeam(teamTaking);
     if (spBody) {
       const sy = 1.5; // drops onto ground via physics; ground collider top is Y=0
       let spawnX = ballFixedPos.x;
@@ -568,10 +640,90 @@ async function main() {
   });
   window.playerControls = playerControls;
 
-  aiPlayer = new AIPlayer(scene, rapierWorld, { spawnZ: 38, targetGoalZ: -50 });
+  // --- TEAM MANAGEMENT ---
+  function removeAI() {
+    if (!aiPlayer) return;
+    if (aiPlayer.model?.parent) aiPlayer.model.parent.remove(aiPlayer.model);
+    if (aiPlayer.character?.nameLabel?.parentNode)
+      aiPlayer.character.nameLabel.parentNode.removeChild(aiPlayer.character.nameLabel);
+    if (aiPlayer.body) rapierWorld.removeRigidBody(aiPlayer.body);
+    aiPlayer = null;
+    aiTeam = null;
+  }
 
+  function spawnAI(team) {
+    removeAI();
+    const spawnZ = team === 'home' ? -38 : 38;
+    const targetGoalZ = team === 'home' ? 50 : -50;
+    const color = team === 'home' ? 0x3399ff : 0xff3322;
+    aiPlayer = new AIPlayer(scene, rapierWorld, { spawnZ, targetGoalZ, color });
+    aiTeam = team;
+  }
 
+  function countRealPlayersByTeam() {
+    const counts = { home: 0, away: 0 };
+    // Only count local player's team if it's been confirmed (not just the initial default)
+    if (localTeamConfirmed && localPlayerTeam) counts[localPlayerTeam]++;
+    Object.values(playerTeams).forEach(t => { if (t) counts[t]++; });
+    return counts;
+  }
 
+  function assignTeamToNewPlayer() {
+    const counts = countRealPlayersByTeam();
+    return counts.away < counts.home ? 'away' : 'home';
+  }
+
+  function updateAIForBalance() {
+    const counts = countRealPlayersByTeam();
+    const needed = counts.home > counts.away ? 'away' : counts.away > counts.home ? 'home' : null;
+    if (needed === aiTeam) return;
+    if (needed === null) removeAI();
+    else spawnAI(needed);
+  }
+
+  function broadcastTeamAssignments() {
+    const myId = multiplayer?.getId?.();
+    const assignments = { ...playerTeams };
+    if (myId) assignments[myId] = localPlayerTeam;
+    multiplayer.send({ type: 'teamAssignments', assignments, aiTeam });
+  }
+
+  function getBodyForTeam(team) {
+    if (localPlayerTeam === team) return playerControls?.body;
+    if (aiTeam === team) return aiPlayer?.body;
+    return null;
+  }
+
+  function rebalanceTeams() {
+    if (!multiplayer?.isHost) return;
+
+    // Assign our own team if not yet confirmed
+    if (!localTeamConfirmed) {
+      const myTeam = assignTeamToNewPlayer();
+      const changed = myTeam !== localPlayerTeam;
+      localPlayerTeam = myTeam;
+      localTeamConfirmed = true;
+      if (changed) {
+        const newColor = myTeam === 'home' ? 0x3399ff : 0xff3322;
+        swapPlayerCharacter(characterModel, newColor);
+      }
+    }
+
+    // Assign any remote players without a confirmed team
+    for (const pid of Object.keys(playerTeams)) {
+      if (!playerTeams[pid]) {
+        playerTeams[pid] = assignTeamToNewPlayer();
+      }
+    }
+
+    updateAIForBalance();
+    broadcastTeamAssignments();
+  }
+
+  // Start in solo mode: local player is home, AI is away
+  spawnAI('away');
+  localPlayerTeam = 'home';
+  localTeamConfirmed = true;
 
   // --- RAPIER HELPERS ---
   function spawnBlock({
@@ -788,8 +940,8 @@ async function main() {
   const toggleBtn = document.getElementById("toggle-console");
   const consoleDiv = document.getElementById("console-log");
 
-  function swapPlayerCharacter(newModelPath) {
-    if (!newModelPath || newModelPath === characterModel) {
+  function swapPlayerCharacter(newModelPath, teamColor = null) {
+    if (!newModelPath || (newModelPath === characterModel && teamColor === null)) {
       return;
     }
 
@@ -803,7 +955,8 @@ async function main() {
       previousModel.remove(playerControls.parachute);
     }
 
-    const newPlayer = new PlayerCharacter(playerName, newModelPath, 0x3399ff);
+    const resolvedColor = teamColor ?? (localPlayerTeam === 'home' ? 0x3399ff : 0xff3322);
+    const newPlayer = new PlayerCharacter(playerName, newModelPath, resolvedColor);
     const newModel = newPlayer.model;
     newModel.position.copy(currentPosition);
     newModel.rotation.copy(currentRotation);
@@ -999,13 +1152,13 @@ async function main() {
           spLocked && spTeam === 'home' ? null : 'home'
         );
       }
-      if (aiPlayer?.body) {
+      if (aiPlayer?.body && aiTeam) {
         soccerBall.resolvePlayerContact(
           aiPlayer.body.translation(),
           aiPlayer.body.linvel(),
           0.3,
           0.6,
-          spLocked && spTeam === 'away' ? null : 'away'
+          spLocked && spTeam === aiTeam ? null : aiTeam
         );
       }
     }
@@ -1060,9 +1213,9 @@ async function main() {
     // walk back into the exclusion zone in the same frame it was pushed out)
     if (setPieceManager?.isActive() && soccerBall) {
       const sp = setPieceManager.active;
-      const isHomeSetPiece = sp.teamTaking === 'home';
-      const setPieceBody = isHomeSetPiece ? playerControls?.body : aiPlayer?.body;
-      const otherBody    = isHomeSetPiece ? aiPlayer?.body    : playerControls?.body;
+      const otherTeam = sp.teamTaking === 'home' ? 'away' : 'home';
+      const setPieceBody = getBodyForTeam(sp.teamTaking);
+      const otherBody    = getBodyForTeam(otherTeam);
       setPieceManager.update(soccerBall, setPieceBody, otherBody);
     }
 
@@ -1071,6 +1224,7 @@ async function main() {
       id: multiplayer.getId(),
       name: playerName,
       model: characterModel,
+      team: localTeamConfirmed ? localPlayerTeam : null,
       x: playerModel.position.x,
       y: playerModel.position.y,
       z: playerModel.position.z,

--- a/app.js
+++ b/app.js
@@ -113,7 +113,6 @@ async function main() {
   }
 
   function handleIncomingData(peerId, data) {
-    console.log('📡 Incoming data:', data);
 
     if (data.type === 'entityControl') {
       if (multiplayer?.isHost && data.id && data.state && data.sourceId) {
@@ -350,7 +349,7 @@ async function main() {
   }
 
   multiplayer = new Multiplayer(playerName, handleIncomingData);
-  multiplayer.onHostChange = ({ previousHostId, newHostId, isCurrentHost }) => {
+  multiplayer.onHostChange = ({ previousHostId, newHostId, isCurrentHost, roomPeerCount = 1 }) => {
     if (previousHostId && previousHostId === multiplayer.getId() && previousHostId !== newHostId) {
       const snapshot = serializeAuthoritativeStates();
       if (newHostId) {
@@ -366,8 +365,10 @@ async function main() {
           requesterId: multiplayer.getId(),
           previousHostId
         });
-        // Becoming host after joining a room with existing players:
-        // reset team confirmation so rebalanceTeams can assign the correct team.
+      }
+      // If there are other players in the room, I'm a new joiner — let rebalanceTeams
+      // pick my team based on what's already occupied rather than defaulting to home.
+      if (roomPeerCount > 1) {
         localTeamConfirmed = false;
       }
       // Rebalance teams after a short delay to allow presences from all peers to arrive
@@ -596,7 +597,7 @@ async function main() {
         soccerBall.body.setLinvel({ x: vx, y: vy, z: vz }, true);
       }
     },
-    isLocallyControlled: () => true
+    isLocallyControlled: () => multiplayer?.isHost !== false
   });
 
 

--- a/peerConnection.js
+++ b/peerConnection.js
@@ -120,7 +120,8 @@ export class Multiplayer {
             this.onHostChange({
               previousHostId,
               newHostId: hostPeerId,
-              isCurrentHost: this.isHost
+              isCurrentHost: this.isHost,
+              roomPeerCount: validPeerIds.length
             });
           } catch (err) {
             console.warn('Host change callback failed:', err);

--- a/peerConnection.js
+++ b/peerConnection.js
@@ -16,6 +16,7 @@ export class Multiplayer {
     this.isHost = false;
     this.currentHostId = null;
     this.onHostChange = null;
+    this.onPeerDisconnect = null;
     
     this.initPeer(); // Start async setup
   }
@@ -246,8 +247,9 @@ export class Multiplayer {
   
     conn.on('close', () => {
       delete this.connections[conn.peer];
+      this.onPeerDisconnect?.(conn.peer);
     });
-  
+
     conn.on('error', err => {
       console.error('Peer error:', err);
     });


### PR DESCRIPTION
## Summary
This PR adds a complete team management system to the multiplayer soccer game, enabling players to be assigned to "home" or "away" teams with visual distinction via team colors. The host automatically balances teams and spawns AI players to maintain equal team sizes.

## Key Changes

- **Team Assignment System**: Players are assigned to teams ('home' or 'away') with persistent tracking via `playerTeams` map. Team assignments are broadcast by the host and applied to all peers.

- **Team-Based Visual Distinction**: Each team has a distinct color (home: 0x3399ff blue, away: 0xff3322 red) applied to player character models. The local player's character is recolored when their team assignment changes.

- **Dynamic AI Balancing**: 
  - `spawnAI()` and `removeAI()` functions manage a single AI player that automatically spawns on whichever team has fewer real players
  - `updateAIForBalance()` is called whenever team composition changes to maintain balance
  - AI player respects team-specific spawn positions and goal targets

- **Host-Driven Team Rebalancing**: 
  - New `rebalanceTeams()` function runs on the host to assign teams to unconfirmed players
  - Triggered on host takeover and after peer connections stabilize (600ms delay)
  - Ensures consistent team assignments across all clients

- **Peer Disconnect Handling**: New `onPeerDisconnect` callback cleans up disconnected player data and triggers rebalancing if the host is still active.

- **Presence Updates**: Local player's presence now includes their confirmed team status, allowing other peers to track team composition.

- **Helper Functions**:
  - `getBodyForTeam(team)`: Returns the physics body for a given team (local player or AI)
  - `countRealPlayersByTeam()`: Counts confirmed real players per team
  - `assignTeamToNewPlayer()`: Assigns new players to the team with fewer members
  - `broadcastTeamAssignments()`: Sends team assignments to all peers

## Notable Implementation Details

- Team confirmation is tracked separately (`localTeamConfirmed`) to distinguish between initial defaults and host-assigned teams
- Model rebuilding is triggered when a player's team changes, ensuring correct color application
- AI team assignment is included in broadcast messages so all peers know which team the AI is on
- Set piece and ball contact logic updated to use `getBodyForTeam()` for team-agnostic team handling
- Solo mode initializes with local player on 'home' team and AI on 'away' team

https://claude.ai/code/session_01FpxRXkzAvTyiK7KkL7yurL