### PR TITLE
AI: Fix model sinking, add formation slots, and single-chaser behavior

### DIFF
--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -16,7 +16,9 @@ const PLAYER_MODEL_HEIGHT_OFFSET = 0.5;
 const FORMATION_X_SPACING = 4;
 const FORMATION_BACK_MARGIN = 12;
 const FORMATION_FRONT_MARGIN = 14;
+const FORMATION_ROLE_Z_SPACING = 10;
 const FORMATION_BALL_X_INFLUENCE = 0.35;
+const FORMATION_ANCHOR_BALL_BLEND = 0.45;
 
 export class AIPlayer {
   constructor(scene, rapierWorld, { spawnX = 0, spawnZ = 35, targetGoalZ = -50, color = 0xff3322, name = 'Computer' } = {}) {
@@ -64,22 +66,33 @@ export class AIPlayer {
     return ballPos.clone().add(backingOffset);
   }
 
-  _getFormationPosition(ballPos, formationIndex, formationCount) {
+  _getFormationPosition(ballPos, formationIndex, formationCount, chaserIndex, chaserPosition) {
     const count = Math.max(1, formationCount);
     const index = Math.max(0, Math.min(count - 1, formationIndex));
+    const anchorIndex = chaserIndex ?? Math.floor((count - 1) / 2);
     const attackDir = Math.sign(this.targetGoalZ - this.ownGoalZ) || 1;
-    const backZ = this.ownGoalZ + attackDir * FORMATION_BACK_MARGIN;
-    const frontZ = this.targetGoalZ - attackDir * FORMATION_FRONT_MARGIN;
-    const roleT = count === 1 ? 0.5 : index / (count - 1);
-    const formationZ = THREE.MathUtils.lerp(backZ, frontZ, roleT);
+    const minZ = Math.min(this.ownGoalZ + attackDir * FORMATION_BACK_MARGIN, this.targetGoalZ - attackDir * FORMATION_FRONT_MARGIN);
+    const maxZ = Math.max(this.ownGoalZ + attackDir * FORMATION_BACK_MARGIN, this.targetGoalZ - attackDir * FORMATION_FRONT_MARGIN);
+
+    // Support players move with the play instead of parking on static field
+    // thirds. Use the ball/chaser as the moving anchor, then keep each role a
+    // few yards ahead or behind that anchor along the attacking direction.
+    const anchorX = chaserPosition
+      ? THREE.MathUtils.lerp(chaserPosition.x, ballPos.x, FORMATION_ANCHOR_BALL_BLEND)
+      : ballPos.x;
+    const anchorZ = chaserPosition
+      ? THREE.MathUtils.lerp(chaserPosition.z, ballPos.z, FORMATION_ANCHOR_BALL_BLEND)
+      : ballPos.z;
+    const roleOffset = (index - anchorIndex) * FORMATION_ROLE_Z_SPACING * attackDir;
+    const formationZ = THREE.MathUtils.clamp(anchorZ + roleOffset, minZ, maxZ);
     const centeredIndex = index - (count - 1) / 2;
     const laneX = centeredIndex * FORMATION_X_SPACING;
-    const ballFollowX = THREE.MathUtils.clamp(ballPos.x * FORMATION_BALL_X_INFLUENCE, -8, 8);
+    const ballFollowX = THREE.MathUtils.clamp((ballPos.x - anchorX) * FORMATION_BALL_X_INFLUENCE, -8, 8);
 
-    return new THREE.Vector3(laneX + ballFollowX, ballPos.y, formationZ);
+    return new THREE.Vector3(anchorX + laneX + ballFollowX, ballPos.y, formationZ);
   }
 
-  update(delta, soccerBall, { pursueBall = true, formationIndex = 0, formationCount = 1 } = {}) {
+  update(delta, soccerBall, { pursueBall = true, formationIndex = 0, formationCount = 1, chaserIndex = null, chaserPosition = null } = {}) {
     if (!this.body) return;
 
     const mixer = this.model.userData.mixer;
@@ -147,7 +160,7 @@ export class AIPlayer {
 
     const targetPos = pursueBall
       ? this._getBallPressurePosition(ballPos)
-      : this._getFormationPosition(ballPos, formationIndex, formationCount);
+      : this._getFormationPosition(ballPos, formationIndex, formationCount, chaserIndex, chaserPosition);
 
     const moveDir = new THREE.Vector3(targetPos.x - t.x, 0, targetPos.z - t.z);
     const dist = moveDir.length();

--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -12,12 +12,18 @@ const KICK_IMPULSE = 0.3;
 const KICK_AIM_SPREAD = 0.35;
 const KICK_REGISTER_DELAY = 250;
 const GROUND_OFFSET = PLAYER_HALF_HEIGHT + PLAYER_RADIUS;
+const PLAYER_MODEL_HEIGHT_OFFSET = 0.5;
+const FORMATION_X_SPACING = 4;
+const FORMATION_BACK_MARGIN = 12;
+const FORMATION_FRONT_MARGIN = 14;
+const FORMATION_BALL_X_INFLUENCE = 0.35;
 
 export class AIPlayer {
   constructor(scene, rapierWorld, { spawnX = 0, spawnZ = 35, targetGoalZ = -50, color = 0xff3322, name = 'Computer' } = {}) {
     this.scene = scene;
     this.rapierWorld = rapierWorld;
     this.targetGoalZ = targetGoalZ;
+    this.ownGoalZ = -targetGoalZ;
 
     this.character = new PlayerCharacter(name, '/models/old_man.fbx', color);
     this.model = this.character.model;
@@ -28,7 +34,7 @@ export class AIPlayer {
     this.kickAnimating = false;
 
     const spawnY = getTerrainHeight(spawnX, spawnZ) + GROUND_OFFSET + 0.5;
-    this.model.position.set(spawnX, spawnY, spawnZ);
+    this.model.position.set(spawnX, spawnY + PLAYER_MODEL_HEIGHT_OFFSET, spawnZ);
 
     const rbDesc = RAPIER.RigidBodyDesc.dynamic()
       .setTranslation(spawnX, spawnY, spawnZ)
@@ -52,7 +58,28 @@ export class AIPlayer {
     this.model.userData.currentAction = actionName;
   }
 
-  update(delta, soccerBall) {
+  _getBallPressurePosition(ballPos) {
+    // Position to approach ball from goal side so AI is behind ball relative to target.
+    const backingOffset = new THREE.Vector3(0, 0, this.targetGoalZ < 0 ? 1.0 : -1.0);
+    return ballPos.clone().add(backingOffset);
+  }
+
+  _getFormationPosition(ballPos, formationIndex, formationCount) {
+    const count = Math.max(1, formationCount);
+    const index = Math.max(0, Math.min(count - 1, formationIndex));
+    const attackDir = Math.sign(this.targetGoalZ - this.ownGoalZ) || 1;
+    const backZ = this.ownGoalZ + attackDir * FORMATION_BACK_MARGIN;
+    const frontZ = this.targetGoalZ - attackDir * FORMATION_FRONT_MARGIN;
+    const roleT = count === 1 ? 0.5 : index / (count - 1);
+    const formationZ = THREE.MathUtils.lerp(backZ, frontZ, roleT);
+    const centeredIndex = index - (count - 1) / 2;
+    const laneX = centeredIndex * FORMATION_X_SPACING;
+    const ballFollowX = THREE.MathUtils.clamp(ballPos.x * FORMATION_BALL_X_INFLUENCE, -8, 8);
+
+    return new THREE.Vector3(laneX + ballFollowX, ballPos.y, formationZ);
+  }
+
+  update(delta, soccerBall, { pursueBall = true, formationIndex = 0, formationCount = 1 } = {}) {
     if (!this.body) return;
 
     const mixer = this.model.userData.mixer;
@@ -79,7 +106,7 @@ export class AIPlayer {
     const now = Date.now();
 
     // Sync model to physics
-    this.model.position.set(t.x, t.y, t.z);
+    this.model.position.set(t.x, t.y + PLAYER_MODEL_HEIGHT_OFFSET, t.z);
 
     if (this.kickAnimating) {
       this.body.setLinvel({ x: 0, y: vel.y, z: 0 }, true);
@@ -118,9 +145,9 @@ export class AIPlayer {
       return;
     }
 
-    // Position to approach ball from goal side so AI is behind ball relative to target
-    const backingOffset = new THREE.Vector3(0, 0, this.targetGoalZ < 0 ? 1.0 : -1.0);
-    const targetPos = ballPos.clone().add(backingOffset);
+    const targetPos = pursueBall
+      ? this._getBallPressurePosition(ballPos)
+      : this._getFormationPosition(ballPos, formationIndex, formationCount);
 
     const moveDir = new THREE.Vector3(targetPos.x - t.x, 0, targetPos.z - t.z);
     const dist = moveDir.length();

--- a/app.js
+++ b/app.js
@@ -1178,7 +1178,7 @@ async function main() {
           spLocked && spTeam === localPlayerTeam ? null : localPlayerTeam
         );
       }
-      Object.values(aiPlayers).forEach((players) => {
+      Object.entries(aiPlayers).forEach(([team, players]) => {
         players.forEach((ai) => {
           if (!ai.body) return;
           soccerBall.resolvePlayerContact(

--- a/app.js
+++ b/app.js
@@ -1238,10 +1238,12 @@ async function main() {
 
     Object.values(aiPlayers).forEach((players) => {
       let ballChaser = null;
+      let ballChaserIndex = -1;
+      let ballChaserPosition = null;
       const ballPos = soccerBall?.getPosition?.();
       if (ballPos) {
         let closestDistSq = Infinity;
-        players.forEach((ai) => {
+        players.forEach((ai, index) => {
           if (!ai.body) return;
           const aiPos = ai.body.translation();
           const dx = aiPos.x - ballPos.x;
@@ -1250,6 +1252,8 @@ async function main() {
           if (distSq < closestDistSq) {
             closestDistSq = distSq;
             ballChaser = ai;
+            ballChaserIndex = index;
+            ballChaserPosition = { x: aiPos.x, y: aiPos.y, z: aiPos.z };
           }
         });
       }
@@ -1258,7 +1262,9 @@ async function main() {
         ai.update(frameDelta, soccerBall, {
           pursueBall: !ballChaser || ai === ballChaser,
           formationIndex: index,
-          formationCount: players.length
+          formationCount: players.length,
+          chaserIndex: ballChaserIndex >= 0 ? ballChaserIndex : null,
+          chaserPosition: ballChaserPosition
         });
       });
     });

--- a/app.js
+++ b/app.js
@@ -1178,7 +1178,7 @@ async function main() {
           spLocked && spTeam === localPlayerTeam ? null : localPlayerTeam
         );
       }
-      Object.entries(aiPlayers).forEach(([team, players]) => {
+      Object.values(aiPlayers).forEach((players) => {
         players.forEach((ai) => {
           if (!ai.body) return;
           soccerBall.resolvePlayerContact(
@@ -1236,8 +1236,31 @@ async function main() {
       p.model.userData.mixer?.update(mixerDelta);
     });
 
-    Object.values(aiPlayers).forEach(players => {
-      players.forEach(ai => ai.update(frameDelta, soccerBall));
+    Object.values(aiPlayers).forEach((players) => {
+      let ballChaser = null;
+      const ballPos = soccerBall?.getPosition?.();
+      if (ballPos) {
+        let closestDistSq = Infinity;
+        players.forEach((ai) => {
+          if (!ai.body) return;
+          const aiPos = ai.body.translation();
+          const dx = aiPos.x - ballPos.x;
+          const dz = aiPos.z - ballPos.z;
+          const distSq = dx * dx + dz * dz;
+          if (distSq < closestDistSq) {
+            closestDistSq = distSq;
+            ballChaser = ai;
+          }
+        });
+      }
+
+      players.forEach((ai, index) => {
+        ai.update(frameDelta, soccerBall, {
+          pursueBall: !ballChaser || ai === ballChaser,
+          formationIndex: index,
+          formationCount: players.length
+        });
+      });
     });
 
     // Set piece zone enforcement (runs after AI update so AI can't immediately


### PR DESCRIPTION
### Motivation
- AI character models appeared visually sunken compared to player characters and multiple computer players clustered on the same spot instead of forming back/mid/front roles.
- Only one computer player per team should actively chase the ball while teammates hold formation to better mimic defender/midfielder/striker roles.

### Description
- Raised AI model display height by adding `PLAYER_MODEL_HEIGHT_OFFSET` and applying it at spawn and during physics-to-model sync so AI models match player display offset (`aiPlayer.js`).
- Added formation support with constants (`FORMATION_X_SPACING`, `FORMATION_BACK_MARGIN`, `FORMATION_FRONT_MARGIN`, `FORMATION_BALL_X_INFLUENCE`) and helper methods `_getFormationPosition` and `_getBallPressurePosition` to compute back/mid/front lane positions and slight ball-side shifting (`aiPlayer.js`).
- Extended `AIPlayer.update` to accept `{ pursueBall, formationIndex, formationCount }` and use formation targets when not pursuing the ball (`aiPlayer.js`).
- Updated the main loop to select the closest AI on each team as the active ball chaser and pass formation index/count to other teammates so they spread into formation slots (`app.js`).
- Files changed: `aiPlayer.js`, `app.js`.

### Testing
- Ran the production build with `npm run build` (Vite) which completed successfully.
- Attempted to run the dev server and capture a screenshot but no browser/playwright was available in the environment, so no visual automated screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45473ca5b08327b07e1b9cf4a308aa)