### PR TITLE
Fix goal scoring colors

### DIFF
--- a/app.js
+++ b/app.js
@@ -446,7 +446,8 @@ async function main() {
 
     // Goal scored?
     if (inX && inY && pos.z > SCORE_FIELD_HALF && vel.z > 0) {
-      score.away++;
+      // Red goal is on the +Z end, so scoring there awards the blue/home score.
+      score.home++;
       updateScoreUI();
       goalCooldown = now + 3000;
       soccerBall.reset();
@@ -456,7 +457,8 @@ async function main() {
       return;
     }
     if (inX && inY && pos.z < -SCORE_FIELD_HALF && vel.z < 0) {
-      score.home++;
+      // Blue goal is on the -Z end, so scoring there awards the red/away score.
+      score.away++;
       updateScoreUI();
       goalCooldown = now + 3000;
       soccerBall.reset();


### PR DESCRIPTION
### Motivation
- The score increments were mapped to the wrong goal ends so the blue/home and red/away counters updated incorrectly.

### Description
- In `app.js` inside `checkGoal()` the +Z (red) goal now increments `score.home` (blue) and the -Z (blue) goal now increments `score.away` (red), with comments added and `updateScoreUI()`/reset behavior preserved.

### Testing
- Ran `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a454e47eb088327bdebaa05ad14f044)