### PR TITLE
Limit multiplayer rooms to 12 online players

### DIFF
--- a/peerConnection.js
+++ b/peerConnection.js
@@ -8,6 +8,8 @@ import {
   onDisconnect
 } from 'firebase/database';
 
+const MAX_ROOM_PLAYERS = 12;
+
 export class Multiplayer {
   constructor(playerName, onPeerData) {
     this.connections = {};
@@ -43,19 +45,28 @@ export class Multiplayer {
 
       const roomsRef = ref(db, 'rooms');
       const snapshot = await get(roomsRef);
+      const peersSnapshot = await get(ref(db, 'peers'));
+      const activePeers = peersSnapshot.exists() ? peersSnapshot.val() : {};
 
       let assignedRoom = null;
       let roomIndex = 0;
 
       if (snapshot.exists()) {
         const rooms = snapshot.val();
-        for (const roomName in rooms) {
-          const peersInRoom = Object.keys(rooms[roomName]);
-          if (peersInRoom.length < 20) {
+        const roomNames = Object.keys(rooms);
+
+        for (const roomName of roomNames) {
+          const peersInRoom = Object.keys(rooms[roomName] || {})
+            .filter(peerId => activePeers[peerId]);
+
+          if (peersInRoom.length < MAX_ROOM_PLAYERS) {
             assignedRoom = roomName;
-            console.log("Entered room: ", assignedRoom)
+            console.log("Entered room: ", assignedRoom);
             break;
           }
+        }
+
+        while (roomNames.includes(`room-${roomIndex}`)) {
           roomIndex++;
         }
       }


### PR DESCRIPTION
### Motivation
- Ensure no room accepts more than 12 online players so that new joiners are placed into a new room when all existing rooms are at capacity.

### Description
- Add a shared `MAX_ROOM_PLAYERS = 12` constant used for room assignment.
- Query `peers` and count only currently active peer IDs when evaluating room occupancy instead of raw room entries.
- Pick an existing room whose active peer count is less than `MAX_ROOM_PLAYERS`, and create a new unused `room-N` if none are available.
- Update room selection logging to reflect the assigned room.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a454ec185c083278602c646645abba2)