### PR TITLE
Fix team balancing and AI synchronization

### DIFF
--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -92,6 +92,38 @@ export class AIPlayer {
     return new THREE.Vector3(anchorX + laneX + ballFollowX, ballPos.y, formationZ);
   }
 
+
+  getState() {
+    if (!this.body) return null;
+    const t = this.body.translation();
+    const v = this.body.linvel();
+    return {
+      position: [t.x, t.y, t.z],
+      linvel: [v.x, v.y, v.z],
+      rotationY: this.model.rotation.y,
+      action: this.model.userData.currentAction || 'idle'
+    };
+  }
+
+  applyState(state) {
+    if (!state || !this.body) return;
+    const [px, py, pz] = state.position || [];
+    const [vx, vy, vz] = state.linvel || [];
+    if (Number.isFinite(px) && Number.isFinite(py) && Number.isFinite(pz)) {
+      this.body.setTranslation({ x: px, y: py, z: pz }, true);
+      this.model.position.set(px, py + PLAYER_MODEL_HEIGHT_OFFSET, pz);
+    }
+    if (Number.isFinite(vx) && Number.isFinite(vy) && Number.isFinite(vz)) {
+      this.body.setLinvel({ x: vx, y: vy, z: vz }, true);
+    }
+    if (Number.isFinite(state.rotationY)) {
+      this.model.rotation.y = state.rotationY;
+    }
+    if (state.action) {
+      this._playAction(state.action);
+    }
+  }
+
   update(delta, soccerBall, { pursueBall = true, formationIndex = 0, formationCount = 1, chaserIndex = null, chaserPosition = null } = {}) {
     if (!this.body) return;
 

--- a/app.js
+++ b/app.js
@@ -166,6 +166,9 @@ async function main() {
         // Store their declared team (null if not yet assigned).
         // rebalanceTeams() will fill in nulls and broadcast final assignments.
         playerTeams[remoteId] = data.team || null;
+        if (multiplayer?.isHost && !playerTeams[remoteId]) {
+          setTimeout(rebalanceTeams, 100);
+        }
       }
 
       const assignedTeam = playerTeams[remoteId] ?? null;
@@ -277,6 +280,7 @@ async function main() {
             localTeamConfirmed = true;
             const newColor = team === 'home' ? 0x3399ff : 0xff3322;
             swapPlayerCharacter(characterModel, newColor);
+            moveLocalPlayerToSpawn(team);
           } else {
             localTeamConfirmed = true;
           }
@@ -627,9 +631,15 @@ async function main() {
 
   const projectiles = [];
 
-  // Player spawns near the -Z goal; AI spawns near +Z goal
-  const PLAYER_SPAWN_Z = -38;
-  const playerSpawnY = getTerrainHeight(0, PLAYER_SPAWN_Z) + 1.5;
+  // Blue/home spawns near the blue (-Z) goal; red/away spawns near the red (+Z) goal.
+  const TEAM_SPAWN_Z = { home: -38, away: 38 };
+
+  function getTeamSpawnPosition(team = localPlayerTeam) {
+    const spawnZ = TEAM_SPAWN_Z[team] ?? TEAM_SPAWN_Z.home;
+    return { x: 0, y: getTerrainHeight(0, spawnZ) + 1.5, z: spawnZ };
+  }
+
+  const initialSpawn = getTeamSpawnPosition('home');
 
   playerControls = new PlayerControls({
     scene,
@@ -640,13 +650,18 @@ async function main() {
     spawnProjectile,
     projectiles,
     audioManager,
-    spawnPosition: { x: 0, y: playerSpawnY, z: PLAYER_SPAWN_Z }
+    spawnPosition: initialSpawn
   });
   window.playerControls = playerControls;
 
   // --- TEAM MANAGEMENT ---
   function removeAI(player) {
     if (!player) return;
+    if (player.networkId) {
+      networkedEntities.delete(player.networkId);
+      pendingEntityStates.delete(player.networkId);
+      authoritativeEntityStates.delete(player.networkId);
+    }
     if (player.model?.parent) player.model.parent.remove(player.model);
     if (player.character?.nameLabel?.parentNode) {
       player.character.nameLabel.parentNode.removeChild(player.character.nameLabel);
@@ -669,7 +684,13 @@ async function main() {
       name: `Computer ${team === 'home' ? 'Home' : 'Away'} ${index + 1}`
     });
     ai.team = team;
+    ai.networkId = `ai-${team}-${index}`;
     aiPlayers[team].push(ai);
+    registerNetworkedEntity(ai.networkId, {
+      getState: () => ai.getState?.(),
+      applyState: state => ai.applyState?.(state),
+      isLocallyControlled: () => multiplayer?.isHost === true
+    });
   }
 
   function setAITeamCounts(counts) {
@@ -721,6 +742,23 @@ async function main() {
     return aiPlayers[team]?.[0]?.body ?? null;
   }
 
+  function moveLocalPlayerToSpawn(team = localPlayerTeam) {
+    const spawn = getTeamSpawnPosition(team);
+    playerModel.position.set(spawn.x, spawn.y, spawn.z);
+    if (playerControls) {
+      playerControls.playerX = spawn.x;
+      playerControls.playerY = spawn.y;
+      playerControls.playerZ = spawn.z;
+      playerControls.lastPosition.set(spawn.x, spawn.y, spawn.z);
+      playerControls.velocity?.set?.(0, 0, 0);
+      if (playerControls.body) {
+        playerControls.body.setTranslation({ x: spawn.x, y: spawn.y, z: spawn.z }, true);
+        playerControls.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+        playerControls.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+      }
+    }
+  }
+
   function rebalanceTeams() {
     if (!multiplayer?.isHost) return;
 
@@ -733,6 +771,7 @@ async function main() {
       if (changed) {
         const newColor = myTeam === 'home' ? 0x3399ff : 0xff3322;
         swapPlayerCharacter(characterModel, newColor);
+        moveLocalPlayerToSpawn(myTeam);
       }
     }
 
@@ -893,8 +932,7 @@ async function main() {
   function respawnPlayer() {
     window.localHealth = 100;
     updateHealthUI();
-    const spawnRY = getTerrainHeight(0, PLAYER_SPAWN_Z) + 1.5;
-    const spawn = { x: 0, y: spawnRY, z: PLAYER_SPAWN_Z };
+    const spawn = getTeamSpawnPosition(localPlayerTeam);
     playerModel.position.set(spawn.x, spawn.y, spawn.z);
     playerControls.playerX = spawn.x;
     playerControls.playerY = spawn.y;
@@ -1261,13 +1299,17 @@ async function main() {
       }
 
       players.forEach((ai, index) => {
-        ai.update(frameDelta, soccerBall, {
-          pursueBall: !ballChaser || ai === ballChaser,
-          formationIndex: index,
-          formationCount: players.length,
-          chaserIndex: ballChaserIndex >= 0 ? ballChaserIndex : null,
-          chaserPosition: ballChaserPosition
-        });
+        if (multiplayer.isHost) {
+          ai.update(frameDelta, soccerBall, {
+            pursueBall: !ballChaser || ai === ballChaser,
+            formationIndex: index,
+            formationCount: players.length,
+            chaserIndex: ballChaserIndex >= 0 ? ballChaserIndex : null,
+            chaserPosition: ballChaserPosition
+          });
+        } else {
+          ai.model.userData.mixer?.update(frameDelta);
+        }
       });
     });
 


### PR DESCRIPTION
### Motivation
- Ensure new joiners are placed on the team with fewer real players instead of defaulting to home.
- Make sure players assigned to the away/red team spawn near the red goal and respawn at the appropriate team spawn.
- Keep computer (AI) players deterministic and synchronized across host and non-host clients so all peers see the same AI poses/positions.

### Description
- Rebalanced team assignment handling in `app.js` by triggering `rebalanceTeams` on the host when an unassigned peer presence arrives and by using `assignTeamToNewPlayer` to pick the team with fewer real players. 
- Added team-specific spawn logic with `TEAM_SPAWN_Z`, `getTeamSpawnPosition` and `moveLocalPlayerToSpawn`, and changed initial spawn/respawn paths to call `getTeamSpawnPosition` so local players spawn at their team goal. 
- Registered AI players as networked entities and cleaned up their network entries on removal by adding `ai.networkId` and calling `registerNetworkedEntity` and deleting entries from `networkedEntities`/`pendingEntityStates`/`authoritativeEntityStates` when an AI is removed. 
- Implemented `getState` and `applyState` in `aiPlayer.js` to serialize AI position/velocity/rotation/action, and updated the main loop so only the host runs `ai.update` while non-hosts update AI mixers and consume authoritative state. 
- Files changed: `app.js` (team/spawn/AI registration and rebalance hooks) and `aiPlayer.js` (AI state serialization/application).

### Testing
- Ran `git diff --check` with no issues detected. (succeeded)
- Ran `npm test -- --runInBand` which failed because there is no `test` script defined in `package.json`. (expected failure)
- Ran `npm run build` (Vite build) and the production build completed successfully. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4561dcfb788327a4e756bfe2277cb5)