### PR TITLE
Add dashboard with Play Online vs Play Bots mode selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import { PlayerCharacter } from "./characters/PlayerCharacter.js";
 import { createClouds, generateSoccerField, createMoon, MOON_RADIUS } from "./worldGeneration.js";
 import { getTerrainHeight } from './water.js';
-import { Multiplayer } from './peerConnection.js';
+import { Multiplayer, subscribeOnlineCount } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
 import { initLogin } from './login.js';
@@ -42,6 +42,29 @@ async function main() {
       setCookie('playerName', username);
       setCookie('characterModel', character || DEFAULT_CHARACTER_MODEL);
       resolve({ username, character: character || DEFAULT_CHARACTER_MODEL });
+    });
+  });
+
+  // ── Dashboard — choose Play Online vs Play Bots ─────────────────────────────
+  const botsOnly = await new Promise(resolve => {
+    const overlay = document.getElementById('dashboard-overlay');
+    const onlineNumEl = document.getElementById('dashboard-online-num');
+    overlay.classList.remove('hidden');
+
+    const unsubCount = subscribeOnlineCount(count => {
+      if (onlineNumEl) onlineNumEl.textContent = count;
+    });
+
+    document.getElementById('btn-play-online').addEventListener('click', () => {
+      unsubCount();
+      overlay.classList.add('hidden');
+      resolve(false);
+    });
+
+    document.getElementById('btn-play-bots').addEventListener('click', () => {
+      unsubCount();
+      overlay.classList.add('hidden');
+      resolve(true);
     });
   });
 
@@ -355,7 +378,7 @@ async function main() {
     }
   }
 
-  multiplayer = new Multiplayer(playerName, handleIncomingData);
+  multiplayer = new Multiplayer(playerName, handleIncomingData, { botsOnly });
   multiplayer.onHostChange = ({ previousHostId, newHostId, isCurrentHost, roomPeerCount = 1 }) => {
     if (previousHostId && previousHostId === multiplayer.getId() && previousHostId !== newHostId) {
       const snapshot = serializeAuthoritativeStates();
@@ -670,7 +693,10 @@ async function main() {
   const winMessage = document.getElementById('win-message');
   const playAgainBtn = document.getElementById('play-again-btn');
 
-  playAgainBtn.addEventListener('click', () => { location.reload(); });
+  playAgainBtn.addEventListener('click', () => {
+    sessionStorage.setItem('skipToGame', '1');
+    location.reload();
+  });
 
   function showWinScreen() {
     const winningTeam = score.home > score.away ? 'home' : score.away > score.home ? 'away' : null;

--- a/index.html
+++ b/index.html
@@ -139,6 +139,29 @@
   </div>
 
   <!-- ══════════════════════════════════════════════
+       DASHBOARD OVERLAY
+  ════════════════════════════════════════════════ -->
+  <div id="dashboard-overlay" class="arcade-overlay hidden">
+    <div class="arcade-panel dashboard-panel">
+      <div class="arcade-title">GOAL QUEST</div>
+      <div class="dashboard-online-count">
+        <span class="dashboard-dot"></span>
+        <span id="dashboard-online-num">0</span> ONLINE
+      </div>
+      <div class="dashboard-btn-group">
+        <button class="arcade-btn arcade-btn-green dashboard-big-btn" id="btn-play-online">
+          ▶ PLAY ONLINE
+        </button>
+        <div class="dashboard-btn-desc">JOIN OTHER PLAYERS</div>
+        <button class="arcade-btn arcade-btn-yellow dashboard-big-btn" id="btn-play-bots">
+          ▶ PLAY VS BOTS
+        </button>
+        <div class="dashboard-btn-desc">PRIVATE — NO RANDOMS</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ══════════════════════════════════════════════
        GAME OVER OVERLAY
   ════════════════════════════════════════════════ -->
   <!-- Game Over Overlay -->
@@ -157,7 +180,7 @@
   <!-- Win Screen Overlay -->
   <div id="win-overlay" class="hidden">
     <div id="win-message"></div>
-    <button id="play-again-btn" class="hidden">Play Again?</button>
+    <button id="play-again-btn" class="hidden">BACK TO MENU</button>
   </div>
 
   <script src="app.js" type="module"></script>

--- a/login.js
+++ b/login.js
@@ -81,7 +81,7 @@ function bindPinInput(inputId, displayId, max = 6) {
 
 // ─── Main init ─────────────────────────────────────────────────────────────────
 
-export function initLogin(onSuccess) {
+export async function initLogin(onSuccess) {
   const overlay = el('login-overlay');
   if (!overlay) return;
 

--- a/login.js
+++ b/login.js
@@ -91,6 +91,14 @@ export function initLogin(onSuccess) {
 
   // Check for existing session
   const sessionUser = getSession();
+  if (sessionUser && sessionStorage.getItem('skipToGame')) {
+    // Fast path: skip welcome screen, go straight to game
+    sessionStorage.removeItem('skipToGame');
+    const user = await getUser(sessionUser);
+    overlay.classList.add('hidden');
+    onSuccess({ username: user?.displayName || sessionUser, character: user?.character || '/models/old_man.fbx' });
+    return;
+  }
   if (sessionUser) {
     const welcomeLabel = el('welcome-name');
     if (welcomeLabel) welcomeLabel.textContent = sessionUser.toUpperCase();

--- a/peerConnection.js
+++ b/peerConnection.js
@@ -26,7 +26,7 @@ const debugNetLog = (...args) => {
 };
 
 export class Multiplayer {
-  constructor(playerName, onPeerData) {
+  constructor(playerName, onPeerData, { botsOnly = false } = {}) {
     this.connections = {};
     this.pendingConnections = new Set();
     this.pendingPayloads = new Map();
@@ -35,6 +35,7 @@ export class Multiplayer {
     this.pendingPings = {};
     this.onPeerData = onPeerData;
     this.playerName = playerName;
+    this.botsOnly = botsOnly;
     this.isHost = false;
     this.currentHostId = null;
     this.onHostChange = null;
@@ -104,28 +105,40 @@ export class Multiplayer {
       let assignedRoom = null;
       let roomIndex = 0;
 
-      if (snapshot.exists()) {
-        const rooms = snapshot.val();
-        const roomNames = Object.keys(rooms);
+      if (this.botsOnly) {
+        // Private bots-only room: find a unique unused room name so no public players can join
+        const existingRoomNames = snapshot.exists() ? Object.keys(snapshot.val()) : [];
+        let botRoomIndex = 0;
+        while (existingRoomNames.includes(`bot-room-${botRoomIndex}`)) {
+          botRoomIndex++;
+        }
+        assignedRoom = `bot-room-${botRoomIndex}`;
+      } else {
+        if (snapshot.exists()) {
+          const rooms = snapshot.val();
+          const roomNames = Object.keys(rooms);
 
-        for (const roomName of roomNames) {
-          const peersInRoom = Object.keys(rooms[roomName] || {})
-            .filter(peerId => activePeers[peerId]);
+          for (const roomName of roomNames) {
+            // Skip private bot rooms
+            if (roomName.startsWith('bot-room-')) continue;
+            const peersInRoom = Object.keys(rooms[roomName] || {})
+              .filter(peerId => activePeers[peerId]);
 
-          if (peersInRoom.length < MAX_ROOM_PLAYERS) {
-            assignedRoom = roomName;
-            debugNetLog('Entered room: ', assignedRoom);
-            break;
+            if (peersInRoom.length < MAX_ROOM_PLAYERS) {
+              assignedRoom = roomName;
+              debugNetLog('Entered room: ', assignedRoom);
+              break;
+            }
+          }
+
+          while (roomNames.includes(`room-${roomIndex}`)) {
+            roomIndex++;
           }
         }
 
-        while (roomNames.includes(`room-${roomIndex}`)) {
-          roomIndex++;
+        if (!assignedRoom) {
+          assignedRoom = `room-${roomIndex}`;
         }
-      }
-
-      if (!assignedRoom) {
-        assignedRoom = `room-${roomIndex}`;
       }
 
       const roomRef = ref(db, `rooms/${assignedRoom}/${id}`);
@@ -194,6 +207,9 @@ export class Multiplayer {
     this.unsubscribePeersListener = onValue(ref(db, 'peers'), snapshot => {
       this.peersCache = snapshot.val() || {};
       this.scheduleHostRecalculation();
+      if (typeof this.onOnlineCount === 'function') {
+        this.onOnlineCount(Object.keys(this.peersCache).length);
+      }
     });
   }
 
@@ -637,4 +653,13 @@ export class Multiplayer {
       }
     });
   }
+}
+
+// Subscribe to online player count without being in the game yet.
+// Returns an unsubscribe function.
+export function subscribeOnlineCount(callback) {
+  return onValue(ref(db, 'peers'), snapshot => {
+    const peers = snapshot.val() || {};
+    callback(Object.keys(peers).length);
+  });
 }

--- a/styles.css
+++ b/styles.css
@@ -996,3 +996,61 @@ body {
   .char-emoji { font-size: 48px; }
   .char-arrow { padding: 10px 12px; font-size: 16px; }
 }
+
+/* ════════════════════════════════════════════════════════
+   DASHBOARD STYLES
+   ════════════════════════════════════════════════════════ */
+
+.dashboard-panel {
+  gap: 24px;
+  min-width: 320px;
+}
+
+.dashboard-online-count {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: #7fff7f;
+  letter-spacing: 0.1em;
+}
+
+.dashboard-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #7fff7f;
+  box-shadow: 0 0 8px #7fff7f;
+  animation: pulse-dot 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.5; transform: scale(0.8); }
+}
+
+.dashboard-btn-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.dashboard-big-btn {
+  width: 100%;
+  font-size: 16px;
+  padding: 16px 24px;
+  letter-spacing: 0.08em;
+}
+
+.dashboard-btn-desc {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: rgba(255,255,255,0.4);
+  letter-spacing: 0.1em;
+  margin-bottom: 8px;
+}


### PR DESCRIPTION
## Summary
This PR introduces a pre-game dashboard that allows players to choose between playing online with other players or in a private bots-only mode. The implementation includes UI components, room isolation logic, and session management improvements.

## Key Changes

- **Dashboard UI**: Added a new overlay screen that displays the current online player count and presents two options: "Play Online" and "Play vs Bots"
- **Bots-only mode**: Extended `Multiplayer` constructor to accept a `botsOnly` option that creates isolated private rooms (prefixed with `bot-room-`) that public players cannot join
- **Room isolation logic**: Modified room assignment to skip bot-only rooms when searching for public multiplayer matches
- **Online count subscription**: Exported new `subscribeOnlineCount()` function to track active players in real-time without requiring game initialization
- **Session fast-path**: Added `skipToGame` session storage flag to bypass the login/welcome screen on replay, allowing players to quickly return to the menu after a match
- **UI improvements**: Updated "Play Again" button text to "BACK TO MENU" and added dashboard styling with retro arcade aesthetic

## Implementation Details

- Bot rooms are identified by the `bot-room-{index}` naming convention and are automatically skipped during public room searches
- The dashboard subscribes to the peers database to display live online player counts
- The `botsOnly` flag is passed through to the multiplayer initialization to control room assignment behavior
- Session management uses `sessionStorage` to enable fast-path login on page reload after completing a match

https://claude.ai/code/session_01RZgdSsEMzeN7HtPG2kwhPR