### PR TITLE
Implement networked set pieces with designated takers

### DIFF
--- a/app.js
+++ b/app.js
@@ -379,13 +379,24 @@ async function main() {
         ballState = { position: [t.x, t.y, t.z], rotation: [r.x, r.y, r.z, r.w], linvel: [v.x, v.y, v.z] };
       }
 
+      // Include active set piece state so the joining client can sync up
+      const activeSP = setPieceManager?.active ?? null;
+      const setPieceState = activeSP ? {
+        spType: activeSP.type,
+        teamTaking: activeSP.teamTaking,
+        ballFixedPos: activeSP.ballFixedPos,
+        zone: activeSP.zone,
+        takerNetworkId: activeSP.takerNetworkId,
+      } : null;
+
       multiplayer.sendTo(requesterId, {
         type: 'joinResponse',
         team: assignedTeam,
         spawnPosition,
         aiStates,
         ballState,
-        gameTimeLeft
+        gameTimeLeft,
+        setPieceState,
       });
 
       broadcastTeamAssignments();
@@ -441,6 +452,31 @@ async function main() {
         Object.entries(aiStates).forEach(([id, state]) => {
           if (state) applyNetworkedState(id, state);
         });
+      }
+      // Restore active set piece if there is one
+      if (data.setPieceState) {
+        applySetPiece(data.setPieceState);
+      }
+      return;
+    }
+
+    if (data.type === 'setPiece') {
+      // Only clients apply; host already applied it in triggerSetPiece
+      if (!multiplayer.isHost) {
+        applySetPiece({
+          spType: data.spType,
+          teamTaking: data.teamTaking,
+          ballFixedPos: data.ballFixedPos,
+          zone: data.zone,
+          takerNetworkId: data.takerNetworkId ?? null,
+        });
+      }
+      return;
+    }
+
+    if (data.type === 'setPieceClear') {
+      if (!multiplayer.isHost) {
+        setPieceManager?.clear();
       }
       return;
     }
@@ -934,8 +970,8 @@ async function main() {
       return;
     }
 
-    // Not a goal — trigger the appropriate set piece
-    triggerSetPiece(pos);
+    // Not a goal — only the host triggers set pieces and broadcasts to clients
+    if (multiplayer.isHost) triggerSetPiece(pos);
   }
 
   function triggerSetPiece(ballOutPos) {
@@ -950,45 +986,90 @@ async function main() {
 
     const { type, teamTaking, ballFixedPos, zone } = params;
 
-    // Place ball at set piece spot
-    soccerBall.body.setTranslation(ballFixedPos, true);
-    soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
-    soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+    // Determine the designated taker: prefer local player if on the taking team,
+    // otherwise fall back to the first AI on that team.
+    let takerNetworkId = null;
+    if (localPlayerTeam === teamTaking) {
+      takerNetworkId = multiplayer.getId();
+    } else {
+      takerNetworkId = aiPlayers[teamTaking]?.[0]?.networkId ?? null;
+    }
 
-    // Teleport the taking player into the zone, offset from the ball so they
-    // don't start overlapping it (which would corrupt lastTouchedTeam tracking).
-    const spBody = getBodyForTeam(teamTaking);
-    if (spBody) {
-      const sy = 1.5; // drops onto ground via physics; ground collider top is Y=0
+    applySetPiece({ spType: type, teamTaking, ballFixedPos, zone, takerNetworkId });
+
+    // Broadcast the set piece to all connected clients
+    multiplayer.send({ type: 'setPiece', spType: type, teamTaking, ballFixedPos, zone, takerNetworkId });
+  }
+
+  // Apply a set piece locally (runs on host via triggerSetPiece and on clients via network message).
+  function applySetPiece({ spType, teamTaking, ballFixedPos, zone, takerNetworkId }) {
+    if (!setPieceManager) return;
+
+    // Place ball at set piece spot
+    if (soccerBall?.body) {
+      soccerBall.body.setTranslation(ballFixedPos, true);
+      soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+      soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+    }
+
+    const myId = multiplayer.getId();
+    const iAmTaker = takerNetworkId !== null && takerNetworkId === myId;
+
+    if (iAmTaker && playerControls?.body) {
+      // Teleport the local player (the designated taker) into the zone
+      const sy = 1.5;
       let spawnX = ballFixedPos.x;
       let spawnZ = ballFixedPos.z;
       const OFFSET = 1.5;
-      if (type === 'throwIn') {
-        // Player stands just outside the sideline, offset in X away from field
+      if (spType === 'throwIn') {
         spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
-      } else if (type === 'cornerKick') {
-        // Player stands outside the field in the corner zone
+      } else if (spType === 'cornerKick') {
         spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
         spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
-      } else if (type === 'goalKick') {
-        // Player stands behind the ball (toward their own goal line)
+      } else if (spType === 'goalKick') {
         spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
       }
-      spBody.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
-      spBody.setLinvel({ x: 0, y: 0, z: 0 }, true);
-      spBody.setAngvel({ x: 0, y: 0, z: 0 }, true);
-
-      // Sync the Three.js model and PlayerControls state for the local player
-      if (teamTaking === 'home' && playerModel && playerControls) {
+      playerControls.body.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
+      playerControls.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
+      playerControls.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
+      if (playerModel) {
         playerModel.position.set(spawnX, sy, spawnZ);
         playerControls.playerX = spawnX;
         playerControls.playerY = sy;
         playerControls.playerZ = spawnZ;
         playerControls.lastPosition.set(spawnX, sy, spawnZ);
       }
+    } else if (multiplayer.isHost) {
+      // Host is not the taker — teleport the AI taker body
+      let takerAIBody = null;
+      outer: for (const team of ['home', 'away']) {
+        for (const ai of (aiPlayers[team] ?? [])) {
+          if (ai.networkId === takerNetworkId) {
+            takerAIBody = ai.body ?? null;
+            break outer;
+          }
+        }
+      }
+      if (takerAIBody) {
+        const sy = 1.5;
+        let spawnX = ballFixedPos.x;
+        let spawnZ = ballFixedPos.z;
+        const OFFSET = 1.5;
+        if (spType === 'throwIn') {
+          spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
+        } else if (spType === 'cornerKick') {
+          spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
+          spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
+        } else if (spType === 'goalKick') {
+          spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
+        }
+        takerAIBody.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
+        takerAIBody.setLinvel({ x: 0, y: 0, z: 0 }, true);
+        takerAIBody.setAngvel({ x: 0, y: 0, z: 0 }, true);
+      }
     }
 
-    setPieceManager.trigger(type, teamTaking, ballFixedPos, zone);
+    setPieceManager.trigger(spType, teamTaking, ballFixedPos, zone, takerNetworkId);
   }
 
   // Load additional level data (destructible props, etc.)
@@ -1796,10 +1877,38 @@ async function main() {
     // walk back into the exclusion zone in the same frame it was pushed out)
     if (setPieceManager?.isActive() && soccerBall) {
       const sp = setPieceManager.active;
-      const otherTeam = sp.teamTaking === 'home' ? 'away' : 'home';
-      const setPieceBody = getBodyForTeam(sp.teamTaking);
-      const otherBody    = getBodyForTeam(otherTeam);
-      setPieceManager.update(soccerBall, setPieceBody, otherBody);
+      const myId = multiplayer.getId();
+
+      // Resolve the designated taker's physics body
+      let takerBody = null;
+      if (sp.takerNetworkId === myId) {
+        takerBody = playerControls?.body ?? null;
+      } else {
+        outer: for (const team of ['home', 'away']) {
+          for (const ai of (aiPlayers[team] ?? [])) {
+            if (ai.networkId === sp.takerNetworkId) {
+              takerBody = ai.body ?? null;
+              break outer;
+            }
+          }
+        }
+      }
+
+      // All other locally-simulated bodies must be pushed out of the zone
+      const otherBodies = [];
+      if (playerControls?.body && playerControls.body !== takerBody) {
+        otherBodies.push(playerControls.body);
+      }
+      for (const team of ['home', 'away']) {
+        for (const ai of (aiPlayers[team] ?? [])) {
+          if (ai.body && ai.body !== takerBody) otherBodies.push(ai.body);
+        }
+      }
+
+      const ended = setPieceManager.update(soccerBall, takerBody, otherBodies);
+      if (ended && multiplayer.isHost) {
+        multiplayer.send({ type: 'setPieceClear' });
+      }
     }
 
     multiplayer.send({

--- a/public/models/golem.json
+++ b/public/models/golem.json
@@ -1,4 +1,4 @@
 {
   "scale": 0.005,
-  "yOffset": 1.0
+  "yOffset": 0.6
 }

--- a/setPiece.js
+++ b/setPiece.js
@@ -25,7 +25,8 @@ export class SetPieceManager {
   // zone: { minX, maxX, minZ, maxZ }
   // ballFixedPos: { x, y, z }
   // teamTaking: 'home' | 'away'
-  trigger(type, teamTaking, ballFixedPos, zone) {
+  // takerNetworkId: network ID of the designated taker (player or AI)
+  trigger(type, teamTaking, ballFixedPos, zone, takerNetworkId) {
     this.clear();
 
     this._buildZoneVisual(zone);
@@ -36,17 +37,18 @@ export class SetPieceManager {
       teamTaking,
       ballFixedPos: { ...ballFixedPos },
       zone: { ...zone },
+      takerNetworkId: takerNetworkId ?? null,
       ballLocked: true,
       startTime: performance.now(),
     };
   }
 
   // Call each frame while a set piece is active.
-  // setPieceBody: Rapier body of the player taking the set piece
-  // otherBody:    Rapier body of the other player (kept out of zone)
+  // setPieceBody: Rapier body of the designated taker (constrained inside zone)
+  // otherBodies:  Array of all other Rapier bodies (pushed out of zone)
   // soccerBall:   SoccerBall instance
   // Returns true if the set piece just ended.
-  update(soccerBall, setPieceBody, otherBody) {
+  update(soccerBall, setPieceBody, otherBodies = []) {
     if (!this.active) return false;
     const a = this.active;
 
@@ -96,9 +98,9 @@ export class SetPieceManager {
       }
     }
 
-    // Keep non-set-piece player out of zone
-    if (otherBody) {
-      this._pushOutOfZone(otherBody, a.zone);
+    // Push every non-taker body out of zone
+    for (const body of otherBodies) {
+      if (body) this._pushOutOfZone(body, a.zone);
     }
 
     // Constrain set piece player within zone


### PR DESCRIPTION
## Summary
This PR refactors set piece handling to support multiplayer synchronization by introducing a designated taker system. Set pieces are now triggered only by the host and broadcast to all clients, ensuring consistent state across the network. The taker (either the local player or an AI) is explicitly designated and their physics body is constrained to the set piece zone while others are pushed out.

## Key Changes

- **Networked Set Piece State**: Added `setPieceState` to join responses so newly connected clients can sync to an active set piece in progress
- **Designated Taker System**: Set pieces now track a `takerNetworkId` to identify which player (local or AI) is taking the set piece, replacing the previous assumption that the taking team's first body was always the taker
- **Host-Only Triggering**: Only the host calls `triggerSetPiece()` when the ball goes out; clients receive the set piece via network message
- **Broadcast Messages**: Added `setPiece` and `setPieceClear` message types to synchronize set piece state across all clients
- **Physics Body Resolution**: Updated set piece update logic to resolve the taker's body by network ID (could be local player or any AI) and push all other bodies out of the zone
- **Improved Taker Selection**: When triggering a set piece, the system prefers the local player if they're on the taking team, otherwise designates the first AI on that team as the taker
- **Model Adjustment**: Fixed golem model Y offset from 1.0 to 0.6 for better positioning

## Implementation Details

- The `applySetPiece()` function now handles both host-side application (via `triggerSetPiece`) and client-side application (via network message)
- Set piece manager's `update()` method now accepts an array of `otherBodies` instead of a single body, allowing proper constraint of multiple non-taker entities
- Network ID tracking enables correct body resolution in multiplayer scenarios where the taker might be a remote player's AI

https://claude.ai/code/session_01REn8Y3mng5GQCE7sgsdrse