### PR TITLE
Add bot team size selector to Play vs Bots mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ async function main() {
   });
 
   // ── Dashboard — choose Play Online vs Play Bots ─────────────────────────────
-  const botsOnly = await new Promise(resolve => {
+  const { botsOnly, botsPerTeam } = await new Promise(resolve => {
     const overlay = document.getElementById('dashboard-overlay');
     const onlineNumEl = document.getElementById('dashboard-online-num');
     overlay.classList.remove('hidden');
@@ -55,16 +55,27 @@ async function main() {
       if (onlineNumEl) onlineNumEl.textContent = count;
     });
 
+    // Bot team size picker (1–5 bots per team)
+    let selectedBotsPerTeam = 3;
+    const sizeDisplay = document.getElementById('bots-size-display');
+    const updateSizeDisplay = () => { sizeDisplay.textContent = selectedBotsPerTeam; };
+    document.getElementById('bots-size-dec').addEventListener('click', () => {
+      if (selectedBotsPerTeam > 1) { selectedBotsPerTeam--; updateSizeDisplay(); }
+    });
+    document.getElementById('bots-size-inc').addEventListener('click', () => {
+      if (selectedBotsPerTeam < 5) { selectedBotsPerTeam++; updateSizeDisplay(); }
+    });
+
     document.getElementById('btn-play-online').addEventListener('click', () => {
       unsubCount();
       overlay.classList.add('hidden');
-      resolve(false);
+      resolve({ botsOnly: false, botsPerTeam: selectedBotsPerTeam });
     });
 
     document.getElementById('btn-play-bots').addEventListener('click', () => {
       unsubCount();
       overlay.classList.add('hidden');
-      resolve(true);
+      resolve({ botsOnly: true, botsPerTeam: selectedBotsPerTeam });
     });
   });
 
@@ -557,7 +568,7 @@ async function main() {
   createClouds(scene);
 
   let soccerBall;
-  const MIN_PLAYERS_PER_TEAM = 3;
+  const MIN_PLAYERS_PER_TEAM = botsOnly ? botsPerTeam : 3;
   const aiPlayers = { home: [], away: [] };
   let setPieceManager;
 

--- a/index.html
+++ b/index.html
@@ -157,6 +157,14 @@
           ▶ PLAY VS BOTS
         </button>
         <div class="dashboard-btn-desc">PRIVATE — NO RANDOMS</div>
+        <div class="bots-team-size-row" id="bots-team-size-row">
+          <span class="bots-team-size-label">BOTS PER TEAM</span>
+          <div class="bots-team-size-controls">
+            <button class="arcade-btn bots-size-btn" id="bots-size-dec">−</button>
+            <span id="bots-size-display">3</span>
+            <button class="arcade-btn bots-size-btn" id="bots-size-inc">+</button>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -1054,3 +1054,43 @@ body {
   letter-spacing: 0.1em;
   margin-bottom: 8px;
 }
+
+.bots-team-size-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 10px 16px;
+  border: 2px solid rgba(255, 220, 0, 0.35);
+  border-radius: 6px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.bots-team-size-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: rgba(255, 220, 0, 0.75);
+  letter-spacing: 0.1em;
+}
+
+.bots-team-size-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.bots-team-size-controls #bots-size-display {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: #fff;
+  min-width: 28px;
+  text-align: center;
+}
+
+.bots-size-btn {
+  font-size: 18px;
+  padding: 4px 14px;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
Added a new team size picker UI to the dashboard that allows players to select how many bots (1–5) should be on each team when playing against bots. The selected bot count is now passed through to the game initialization.

## Key Changes
- **UI Component**: Added a new "BOTS PER TEAM" control section below the "Play vs Bots" button with decrement/increment buttons and a display showing the current selection (defaults to 3)
- **Styling**: Added three new CSS classes (`.bots-team-size-row`, `.bots-team-size-label`, `.bots-team-size-controls`, `.bots-size-btn`) to style the bot picker with arcade-themed aesthetics matching the existing design
- **Game Logic**: Modified the dashboard promise to return an object containing both `botsOnly` and `botsPerTeam` instead of just a boolean
- **Bot Count Integration**: Updated `MIN_PLAYERS_PER_TEAM` to use the selected `botsPerTeam` value when in bot-only mode, allowing dynamic team sizing

## Implementation Details
- Bot team size is constrained to 1–5 players per team with increment/decrement buttons
- The selection persists across the dashboard interaction and is passed to game initialization
- Styling uses the existing "Press Start 2P" monospace font and yellow accent color (`rgba(255, 220, 0, ...)`) to maintain visual consistency with the arcade theme
- The control is only relevant in bot-only mode but is always available on the dashboard

https://claude.ai/code/session_019QKhfVJupLuTh3RiWN6k6t