### PR TITLE
Add exclusion zones for set pieces to enforce opponent positioning

### DIFF
--- a/app.js
+++ b/app.js
@@ -458,6 +458,7 @@ async function main() {
         teamTaking: activeSP.teamTaking,
         ballFixedPos: activeSP.ballFixedPos,
         zone: activeSP.zone,
+        exclusionZone: activeSP.exclusionZone,
         takerNetworkId: activeSP.takerNetworkId,
       } : null;
 
@@ -549,6 +550,7 @@ async function main() {
           teamTaking: data.teamTaking,
           ballFixedPos: data.ballFixedPos,
           zone: data.zone,
+          exclusionZone: data.exclusionZone ?? null,
           takerNetworkId: data.takerNetworkId ?? null,
         });
       }
@@ -1079,7 +1081,7 @@ async function main() {
       return;
     }
 
-    const { type, teamTaking, ballFixedPos, zone } = params;
+    const { type, teamTaking, ballFixedPos, zone, exclusionZone } = params;
 
     // Determine the designated taker: prefer local player if on the taking team,
     // otherwise fall back to the first AI on that team.
@@ -1090,14 +1092,14 @@ async function main() {
       takerNetworkId = aiPlayers[teamTaking]?.[0]?.networkId ?? null;
     }
 
-    applySetPiece({ spType: type, teamTaking, ballFixedPos, zone, takerNetworkId });
+    applySetPiece({ spType: type, teamTaking, ballFixedPos, zone, exclusionZone, takerNetworkId });
 
     // Broadcast the set piece to all connected clients
-    multiplayer.send({ type: 'setPiece', spType: type, teamTaking, ballFixedPos, zone, takerNetworkId });
+    multiplayer.send({ type: 'setPiece', spType: type, teamTaking, ballFixedPos, zone, exclusionZone, takerNetworkId });
   }
 
   // Apply a set piece locally (runs on host via triggerSetPiece and on clients via network message).
-  function applySetPiece({ spType, teamTaking, ballFixedPos, zone, takerNetworkId }) {
+  function applySetPiece({ spType, teamTaking, ballFixedPos, zone, exclusionZone, takerNetworkId }) {
     if (!setPieceManager) return;
 
     // Place ball at set piece spot
@@ -1164,7 +1166,7 @@ async function main() {
       }
     }
 
-    setPieceManager.trigger(spType, teamTaking, ballFixedPos, zone, takerNetworkId);
+    setPieceManager.trigger(spType, teamTaking, ballFixedPos, zone, takerNetworkId, exclusionZone);
   }
 
   // Load additional level data (destructible props, etc.)
@@ -1994,18 +1996,28 @@ async function main() {
         }
       }
 
-      // All other locally-simulated bodies must be pushed out of the zone
+      // Split locally-simulated bodies into two groups:
+      // - otherBodies: all non-taker bodies pushed out of the small taker zone
+      // - opposingBodies: only opposing team bodies pushed out of the larger exclusion zone
+      const opposingTeam = sp.teamTaking === 'home' ? 'away' : 'home';
       const otherBodies = [];
+      const opposingBodies = [];
       if (playerControls?.body && playerControls.body !== takerBody) {
         otherBodies.push(playerControls.body);
+        if (localPlayerTeam === opposingTeam) {
+          opposingBodies.push(playerControls.body);
+        }
       }
       for (const team of ['home', 'away']) {
         for (const ai of (aiPlayers[team] ?? [])) {
-          if (ai.body && ai.body !== takerBody) otherBodies.push(ai.body);
+          if (ai.body && ai.body !== takerBody) {
+            otherBodies.push(ai.body);
+            if (team === opposingTeam) opposingBodies.push(ai.body);
+          }
         }
       }
 
-      const ended = setPieceManager.update(soccerBall, takerBody, otherBodies);
+      const ended = setPieceManager.update(soccerBall, takerBody, otherBodies, opposingBodies);
       if (ended && multiplayer.isHost) {
         multiplayer.send({ type: 'setPieceClear' });
       }

--- a/setPiece.js
+++ b/setPiece.js
@@ -23,13 +23,15 @@ export class SetPieceManager {
   }
 
   // zone: { minX, maxX, minZ, maxZ }
+  // exclusionZone: { minX, maxX, minZ, maxZ } – opposing team must stay outside this
   // ballFixedPos: { x, y, z }
   // teamTaking: 'home' | 'away'
   // takerNetworkId: network ID of the designated taker (player or AI)
-  trigger(type, teamTaking, ballFixedPos, zone, takerNetworkId) {
+  trigger(type, teamTaking, ballFixedPos, zone, takerNetworkId, exclusionZone) {
     this.clear();
 
     this._buildZoneVisual(zone);
+    if (exclusionZone) this._buildExclusionZoneVisual(exclusionZone);
     this._showLabel(type, teamTaking);
 
     this.active = {
@@ -37,6 +39,7 @@ export class SetPieceManager {
       teamTaking,
       ballFixedPos: { ...ballFixedPos },
       zone: { ...zone },
+      exclusionZone: exclusionZone ? { ...exclusionZone } : null,
       takerNetworkId: takerNetworkId ?? null,
       ballLocked: true,
       startTime: performance.now(),
@@ -44,11 +47,12 @@ export class SetPieceManager {
   }
 
   // Call each frame while a set piece is active.
-  // setPieceBody: Rapier body of the designated taker (constrained inside zone)
-  // otherBodies:  Array of all other Rapier bodies (pushed out of zone)
-  // soccerBall:   SoccerBall instance
+  // setPieceBody:   Rapier body of the designated taker (constrained inside zone)
+  // otherBodies:    Array of all other Rapier bodies (pushed out of taker zone)
+  // opposingBodies: Array of opposing team Rapier bodies (pushed out of exclusion zone)
+  // soccerBall:     SoccerBall instance
   // Returns true if the set piece just ended.
-  update(soccerBall, setPieceBody, otherBodies = []) {
+  update(soccerBall, setPieceBody, otherBodies = [], opposingBodies = []) {
     if (!this.active) return false;
     const a = this.active;
 
@@ -98,9 +102,16 @@ export class SetPieceManager {
       }
     }
 
-    // Push every non-taker body out of zone
+    // Push every non-taker body out of taker zone
     for (const body of otherBodies) {
       if (body) this._pushOutOfZone(body, a.zone);
+    }
+
+    // Push opposing team bodies out of the larger exclusion zone
+    if (a.exclusionZone) {
+      for (const body of opposingBodies) {
+        if (body) this._pushOutOfZone(body, a.exclusionZone);
+      }
     }
 
     // Constrain set piece player within zone
@@ -155,6 +166,39 @@ export class SetPieceManager {
     // Wireframe walls
     const edgesGeo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, boxH, d));
     const edgesMat = new THREE.LineBasicMaterial({ color: 0xffff00 });
+    const edges = new THREE.LineSegments(edgesGeo, edgesMat);
+    edges.position.set(cx, y + boxH / 2, cz);
+    this.scene.add(edges);
+    this._zoneMeshes.push(edges);
+  }
+
+  _buildExclusionZoneVisual(zone) {
+    const { minX, maxX, minZ, maxZ } = zone;
+    const cx = (minX + maxX) / 2;
+    const cz = (minZ + maxZ) / 2;
+    const w = maxX - minX;
+    const d = maxZ - minZ;
+    const y = 0.015;
+    const boxH = 2.5;
+
+    // Translucent red floor
+    const floorGeo = new THREE.PlaneGeometry(w, d);
+    const floorMat = new THREE.MeshBasicMaterial({
+      color: 0xff2200,
+      transparent: true,
+      opacity: 0.12,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const floor = new THREE.Mesh(floorGeo, floorMat);
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.set(cx, y, cz);
+    this.scene.add(floor);
+    this._zoneMeshes.push(floor);
+
+    // Red wireframe walls
+    const edgesGeo = new THREE.EdgesGeometry(new THREE.BoxGeometry(w, boxH, d));
+    const edgesMat = new THREE.LineBasicMaterial({ color: 0xff2200 });
     const edges = new THREE.LineSegments(edgesGeo, edgesMat);
     edges.position.set(cx, y + boxH / 2, cz);
     this.scene.add(edges);
@@ -280,7 +324,15 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
       minZ: clampedZ - hw,
       maxZ: clampedZ + hw,
     };
-    return { type: 'throwIn', teamTaking, ballFixedPos, zone };
+    // Opposing team must stay 9 units away from the throw-in spot (field side only)
+    const exHW = 9;
+    const exclusionZone = {
+      minX: xSign > 0 ? sideX - exHW : sideX,
+      maxX: xSign > 0 ? sideX : sideX + exHW,
+      minZ: clampedZ - exHW,
+      maxZ: clampedZ + exHW,
+    };
+    return { type: 'throwIn', teamTaking, ballFixedPos, zone, exclusionZone };
   }
 
   if (outZ) {
@@ -308,7 +360,15 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
         minZ: zSign > 0 ? cornerZ : cornerZ - extent,
         maxZ: zSign > 0 ? cornerZ + extent : cornerZ,
       };
-      return { type: 'cornerKick', teamTaking, ballFixedPos, zone };
+      // Opposing team must stay 9 units from the corner (on the field side)
+      const exExtent = 9;
+      const exclusionZone = {
+        minX: xSign > 0 ? cornerX - exExtent : cornerX,
+        maxX: xSign > 0 ? cornerX : cornerX + exExtent,
+        minZ: zSign > 0 ? cornerZ - exExtent : cornerZ,
+        maxZ: zSign > 0 ? cornerZ : cornerZ + exExtent,
+      };
+      return { type: 'cornerKick', teamTaking, ballFixedPos, zone, exclusionZone };
     } else {
       // ── GOAL KICK ───────────────────────────────────────────────────────
       // Attacker kicked it out → goal kick for defenders
@@ -326,7 +386,16 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
         minZ: zSign > 0 ? FIELD_HALF_Z - zoneDepth : -FIELD_HALF_Z,
         maxZ: zSign > 0 ? FIELD_HALF_Z             : -FIELD_HALF_Z + zoneDepth,
       };
-      return { type: 'goalKick', teamTaking, ballFixedPos, zone };
+      // Opposing team must stay outside the penalty area (16 wide × 18 deep from goal line)
+      const exHalfW = 13;
+      const exDepth = 18;
+      const exclusionZone = {
+        minX: -exHalfW,
+        maxX:  exHalfW,
+        minZ: zSign > 0 ? FIELD_HALF_Z - exDepth : -FIELD_HALF_Z,
+        maxZ: zSign > 0 ? FIELD_HALF_Z           : -FIELD_HALF_Z + exDepth,
+      };
+      return { type: 'goalKick', teamTaking, ballFixedPos, zone, exclusionZone };
     }
   }
 


### PR DESCRIPTION
## Summary
This PR introduces exclusion zones for set pieces (throw-ins, corner kicks, and goal kicks) to enforce that opposing team players must stay outside designated areas during set piece execution. This complements the existing taker zone constraint and provides more realistic soccer set piece rules.

## Key Changes

- **SetPieceManager enhancements:**
  - Added `exclusionZone` parameter to `trigger()` method to define areas where opposing team must stay out
  - Extended `update()` method to accept `opposingBodies` array and enforce exclusion zone constraints
  - Added `_buildExclusionZoneVisual()` method to render exclusion zones as translucent red floor with wireframe walls (matching taker zone visual style)

- **Set piece parameter generation:**
  - Updated `buildSetPieceParams()` to calculate and return exclusion zones for all set piece types:
    - **Throw-ins:** 9-unit exclusion zone around the throw-in spot (field side only)
    - **Corner kicks:** 9-unit exclusion zone from the corner (on field side)
    - **Goal kicks:** 13×18 unit exclusion zone covering the penalty area
  - Exclusion zones are asymmetrical to respect field boundaries and set piece positioning rules

- **App integration:**
  - Updated set piece data serialization/deserialization to include `exclusionZone`
  - Modified physics update loop to separate bodies into `otherBodies` (pushed out of taker zone) and `opposingBodies` (pushed out of exclusion zone)
  - Opposing team bodies are identified and tracked separately for proper constraint application

## Implementation Details

- Exclusion zones use the same `_pushOutOfZone()` constraint mechanism as taker zones, ensuring consistent physics behavior
- Visual representation uses red coloring (vs. blue for taker zones) to distinguish exclusion zones
- Exclusion zones are optional and only enforced when defined (backward compatible)
- Opposing team identification is dynamic based on `teamTaking` parameter

https://claude.ai/code/session_011AocniynBoqYsTnxwTmdmM