### PR TITLE
Prioritize set piece taker as ball chaser during active set pieces

### DIFF
--- a/app.js
+++ b/app.js
@@ -2269,12 +2269,27 @@ async function main() {
       p.model.userData.mixer?.update(mixerDelta);
     });
 
-    Object.values(aiPlayers).forEach((players) => {
+    Object.entries(aiPlayers).forEach(([team, players]) => {
       let ballChaser = null;
       let ballChaserIndex = -1;
       let ballChaserPosition = null;
       const ballPos = soccerBall?.getPosition?.();
-      if (ballPos) {
+
+      // During a set piece, force the designated taker (if on this team) to be
+      // the ball chaser so they always approach and kick rather than standing in
+      // formation while a different bot chases.
+      const sp = setPieceManager?.isActive() ? setPieceManager.active : null;
+      if (sp && sp.teamTaking === team) {
+        const takerAi = players.find(ai => ai.networkId === sp.takerNetworkId);
+        if (takerAi?.body) {
+          const aiPos = takerAi.body.translation();
+          ballChaser = takerAi;
+          ballChaserIndex = players.indexOf(takerAi);
+          ballChaserPosition = { x: aiPos.x, y: aiPos.y, z: aiPos.z };
+        }
+      }
+
+      if (!ballChaser && ballPos) {
         let closestDistSq = Infinity;
         players.forEach((ai, index) => {
           if (!ai.body) return;


### PR DESCRIPTION
## Summary
Modified the AI player ball-chasing logic to prioritize the designated set piece taker when a set piece is active, ensuring they approach and kick the ball rather than standing in formation while another bot chases.

## Key Changes
- Changed `Object.values(aiPlayers)` to `Object.entries(aiPlayers)` to access both team identifier and players list
- Added set piece detection logic that checks if a set piece is active and if the current team is taking it
- When a set piece is active for the team, the designated taker (matched by `networkId`) is forced to be the ball chaser
- The ball chaser selection now only falls back to proximity-based selection if no set piece taker is assigned (`if (!ballChaser && ballPos)`)

## Implementation Details
- The set piece taker is identified by matching their `networkId` against `sp.takerNetworkId`
- Ball chaser position is extracted from the taker's body translation
- The logic gracefully handles cases where the taker AI body is not available or the set piece is inactive

https://claude.ai/code/session_01Xv4SeuS9WLvTp8Rzg8zerm