### PR TITLE
Add customizable bot game settings (ball size & gravity)

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,8 +46,9 @@ async function main() {
   });
 
   // ── Dashboard — choose Play Online vs Play Bots ─────────────────────────────
-  const { botsOnly, botsPerTeam } = await new Promise(resolve => {
+  const { botsOnly, botsPerTeam, ballSizeMultiplier, gravityMultiplier } = await new Promise(resolve => {
     const overlay = document.getElementById('dashboard-overlay');
+    const settingsOverlay = document.getElementById('bots-settings-overlay');
     const onlineNumEl = document.getElementById('dashboard-online-num');
     overlay.classList.remove('hidden');
 
@@ -55,27 +56,64 @@ async function main() {
       if (onlineNumEl) onlineNumEl.textContent = count;
     });
 
-    // Bot team size picker (1–5 bots per team)
-    let selectedBotsPerTeam = 3;
-    const sizeDisplay = document.getElementById('bots-size-display');
-    const updateSizeDisplay = () => { sizeDisplay.textContent = selectedBotsPerTeam; };
+    // Bot settings — load from cookies
+    let selectedBotsPerTeam = parseInt(getCookie('botsPerTeam') || '3', 10);
+    let selectedBallSize = parseFloat(getCookie('ballSizeMultiplier') || '1.0');
+    let selectedGravity = parseFloat(getCookie('gravityMultiplier') || '1.0');
+
+    const botsDisplay = document.getElementById('bots-size-display');
+    const ballDisplay = document.getElementById('ball-size-display');
+    const gravDisplay = document.getElementById('gravity-display');
+
+    const refreshDisplays = () => {
+      botsDisplay.textContent = selectedBotsPerTeam;
+      ballDisplay.textContent = selectedBallSize.toFixed(1);
+      gravDisplay.textContent = selectedGravity.toFixed(1);
+    };
+    refreshDisplays();
+
     document.getElementById('bots-size-dec').addEventListener('click', () => {
-      if (selectedBotsPerTeam > 1) { selectedBotsPerTeam--; updateSizeDisplay(); }
+      if (selectedBotsPerTeam > 1) { selectedBotsPerTeam--; refreshDisplays(); }
     });
     document.getElementById('bots-size-inc').addEventListener('click', () => {
-      if (selectedBotsPerTeam < 5) { selectedBotsPerTeam++; updateSizeDisplay(); }
+      if (selectedBotsPerTeam < 5) { selectedBotsPerTeam++; refreshDisplays(); }
+    });
+    document.getElementById('ball-size-dec').addEventListener('click', () => {
+      if (selectedBallSize > 0.5) { selectedBallSize = Math.round((selectedBallSize - 0.1) * 10) / 10; refreshDisplays(); }
+    });
+    document.getElementById('ball-size-inc').addEventListener('click', () => {
+      if (selectedBallSize < 3.0) { selectedBallSize = Math.round((selectedBallSize + 0.1) * 10) / 10; refreshDisplays(); }
+    });
+    document.getElementById('gravity-dec').addEventListener('click', () => {
+      if (selectedGravity > 0.1) { selectedGravity = Math.round((selectedGravity - 0.1) * 10) / 10; refreshDisplays(); }
+    });
+    document.getElementById('gravity-inc').addEventListener('click', () => {
+      if (selectedGravity < 2.0) { selectedGravity = Math.round((selectedGravity + 0.1) * 10) / 10; refreshDisplays(); }
     });
 
     document.getElementById('btn-play-online').addEventListener('click', () => {
       unsubCount();
       overlay.classList.add('hidden');
-      resolve({ botsOnly: false, botsPerTeam: selectedBotsPerTeam });
+      resolve({ botsOnly: false, botsPerTeam: selectedBotsPerTeam, ballSizeMultiplier: 1.0, gravityMultiplier: 1.0 });
     });
 
     document.getElementById('btn-play-bots').addEventListener('click', () => {
-      unsubCount();
       overlay.classList.add('hidden');
-      resolve({ botsOnly: true, botsPerTeam: selectedBotsPerTeam });
+      settingsOverlay.classList.remove('hidden');
+    });
+
+    document.getElementById('bots-settings-back').addEventListener('click', () => {
+      settingsOverlay.classList.add('hidden');
+      overlay.classList.remove('hidden');
+    });
+
+    document.getElementById('bots-settings-start').addEventListener('click', () => {
+      setCookie('botsPerTeam', String(selectedBotsPerTeam));
+      setCookie('ballSizeMultiplier', selectedBallSize.toFixed(1));
+      setCookie('gravityMultiplier', selectedGravity.toFixed(1));
+      unsubCount();
+      settingsOverlay.classList.add('hidden');
+      resolve({ botsOnly: true, botsPerTeam: selectedBotsPerTeam, ballSizeMultiplier: selectedBallSize, gravityMultiplier: selectedGravity });
     });
 
     // Stats button
@@ -1528,7 +1566,7 @@ async function main() {
 
   // --- RAPIER INIT ---
   await RAPIER.init();
-  rapierWorld = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
+  rapierWorld = new RAPIER.World({ x: 0, y: -9.81 * gravityMultiplier, z: 0 });
   window.rapierWorld = rapierWorld;
   window.rbToMesh = rbToMesh;
   breakManager.setWorld(rapierWorld);
@@ -1550,7 +1588,7 @@ async function main() {
   setPieceManager = new SetPieceManager(scene);
 
   soccerBall = new SoccerBall(scene, rapierWorld, rbToMesh);
-  soccerBall.create(0, 1, 0);
+  soccerBall.create(0, 1, 0, ballSizeMultiplier);
   registerNetworkedEntity('soccerball', {
     getState: () => {
       if (!soccerBall?.body) return null;

--- a/index.html
+++ b/index.html
@@ -160,20 +160,52 @@
           ▶ PLAY VS BOTS
         </button>
         <div class="dashboard-btn-desc">PRIVATE — NO RANDOMS</div>
-        <div class="bots-team-size-row" id="bots-team-size-row">
-          <span class="bots-team-size-label">BOTS PER TEAM</span>
-          <div class="bots-team-size-controls">
-            <button class="arcade-btn bots-size-btn" id="bots-size-dec">−</button>
-            <span id="bots-size-display">3</span>
-            <button class="arcade-btn bots-size-btn" id="bots-size-inc">+</button>
-          </div>
-        </div>
         <div class="dashboard-secondary-btns">
           <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn" id="btn-stats">📊 MY STATS</button>
           <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn" id="btn-leaderboard-dash">🏆 LEADERBOARD</button>
           <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn" id="btn-profile">👤 PROFILE</button>
         </div>
       </div>
+    </div>
+  </div>
+
+  <!-- Bots Settings Overlay -->
+  <div id="bots-settings-overlay" class="arcade-overlay hidden">
+    <div class="arcade-panel bots-settings-panel">
+      <div class="arcade-title" style="font-size: clamp(14px,3vw,20px)">BOT GAME SETTINGS</div>
+
+      <div class="bots-setting-row">
+        <span class="bots-setting-label">BOTS PER TEAM</span>
+        <div class="bots-setting-controls">
+          <button class="arcade-btn bots-size-btn" id="bots-size-dec">−</button>
+          <span id="bots-size-display">3</span>
+          <button class="arcade-btn bots-size-btn" id="bots-size-inc">+</button>
+        </div>
+      </div>
+
+      <div class="bots-setting-row">
+        <span class="bots-setting-label">BALL SIZE</span>
+        <div class="bots-setting-controls">
+          <button class="arcade-btn bots-size-btn" id="ball-size-dec">−</button>
+          <span id="ball-size-display">1.0</span>
+          <button class="arcade-btn bots-size-btn" id="ball-size-inc">+</button>
+        </div>
+      </div>
+
+      <div class="bots-setting-row">
+        <span class="bots-setting-label">GRAVITY</span>
+        <div class="bots-setting-controls">
+          <button class="arcade-btn bots-size-btn" id="gravity-dec">−</button>
+          <span id="gravity-display">1.0</span>
+          <button class="arcade-btn bots-size-btn" id="gravity-inc">+</button>
+        </div>
+        <div class="bots-setting-hint">LOWER = MORE FLOATY</div>
+      </div>
+
+      <button class="arcade-btn arcade-btn-yellow bots-settings-start-btn" id="bots-settings-start">
+        ▶ START GAME
+      </button>
+      <button class="arcade-btn arcade-btn-dim bots-settings-back-btn" id="bots-settings-back">◀ BACK</button>
     </div>
   </div>
 

--- a/soccerBall.js
+++ b/soccerBall.js
@@ -13,7 +13,8 @@ export class SoccerBall {
     this.lastTouchedTeam = null; // 'home' | 'away' | null
   }
 
-  create(x = 0, y = 1, z = 0) {
+  create(x = 0, y = 1, z = 0, sizeMultiplier = 1.0) {
+    const ballRadius = BALL_RADIUS * sizeMultiplier;
     // Build a simple black-and-white soccer ball using canvas texture
     const canvas = document.createElement('canvas');
     canvas.width = 256;
@@ -41,12 +42,14 @@ export class SoccerBall {
     }
     const texture = new THREE.CanvasTexture(canvas);
 
-    const geo = new THREE.SphereGeometry(BALL_RADIUS, 16, 16);
+    const geo = new THREE.SphereGeometry(ballRadius, 16, 16);
     const mat = new THREE.MeshStandardMaterial({ map: texture, roughness: 0.6 });
     this.mesh = new THREE.Mesh(geo, mat);
     this.mesh.castShadow = true;
     this.mesh.position.set(x, y, z);
     this.scene.add(this.mesh);
+
+    this.ballRadius = ballRadius;
 
     // Dynamic physics body
     const rbDesc = RAPIER.RigidBodyDesc.dynamic()
@@ -56,7 +59,7 @@ export class SoccerBall {
       .setCcdEnabled(true);
     this.body = this.rapierWorld.createRigidBody(rbDesc);
 
-    const colDesc = RAPIER.ColliderDesc.ball(BALL_RADIUS)
+    const colDesc = RAPIER.ColliderDesc.ball(ballRadius)
       .setRestitution(0.7)
       .setFriction(0.4)
       .setDensity(0.5);
@@ -101,7 +104,7 @@ export class SoccerBall {
     const dy = t.y - closestY;
     const dz = t.z - playerPos.z;
     const distSq = dx * dx + dy * dy + dz * dz;
-    const minDist = BALL_RADIUS + playerRadius;
+    const minDist = (this.ballRadius ?? BALL_RADIUS) + playerRadius;
     const dist = Math.sqrt(distSq);
     if (dist >= minDist || dist < 1e-4) return;
 

--- a/styles.css
+++ b/styles.css
@@ -1112,6 +1112,67 @@ body {
   line-height: 1;
 }
 
+/* Bots settings overlay */
+.bots-settings-panel {
+  gap: 20px;
+  min-width: 320px;
+  max-width: 400px;
+  width: 90%;
+}
+
+.bots-setting-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 16px;
+  border: 2px solid rgba(255, 220, 0, 0.35);
+  border-radius: 6px;
+  box-sizing: border-box;
+}
+
+.bots-setting-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: rgba(255, 220, 0, 0.85);
+  letter-spacing: 0.1em;
+}
+
+.bots-setting-hint {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.05em;
+}
+
+.bots-setting-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.bots-setting-controls span {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: #fff;
+  min-width: 40px;
+  text-align: center;
+}
+
+.bots-settings-start-btn {
+  width: 100%;
+  font-size: 16px;
+  padding: 16px 24px;
+  letter-spacing: 0.08em;
+  margin-top: 4px;
+}
+
+.bots-settings-back-btn {
+  font-size: 10px;
+  padding: 8px 16px;
+}
+
 .dashboard-secondary-btns {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary
This PR adds a dedicated settings overlay for bot games, allowing players to customize ball size and gravity multipliers before starting a match. Settings are persisted via cookies for convenience.

## Key Changes
- **New Bot Settings Overlay**: Created a separate modal (`bots-settings-overlay`) that appears when "Play vs Bots" is selected, replacing the inline controls on the dashboard
- **Ball Size Multiplier**: Added adjustable ball size (0.5x to 3.0x) that scales the soccer ball's geometry and physics collider
- **Gravity Multiplier**: Added adjustable gravity (0.1x to 2.0x) that modifies the physics world's gravity vector
- **Cookie Persistence**: Bot settings (bots per team, ball size, gravity) are now saved to cookies and restored on page load
- **Updated SoccerBall Class**: Modified `create()` method to accept `sizeMultiplier` parameter and store the calculated ball radius for accurate collision detection
- **Improved UI/UX**: 
  - Moved bot team size picker into the new settings panel
  - Added visual styling for settings rows with labels and hints
  - Implemented back button to return to dashboard without starting game
  - Settings are only applied when "Start Game" is clicked

## Implementation Details
- Ball size multiplier is applied only in bot games (online games always use 1.0x)
- Gravity multiplier is applied to the RAPIER physics world initialization
- All numeric adjustments use 0.1 increments with proper rounding to avoid floating-point precision issues
- Ball collision detection uses the stored `ballRadius` to ensure accurate physics with scaled balls

https://claude.ai/code/session_01XbW924jcq5DoZkoNE4YqNg