### PR TITLE
Set scoreAuthoritative flag when host is current

### DIFF
--- a/app.js
+++ b/app.js
@@ -944,6 +944,7 @@ async function main() {
     }
 
     if (isCurrentHost) {
+      scoreAuthoritative = true;
       lastEntityBroadcast = 0;
       if (previousHostId && previousHostId !== multiplayer.getId()) {
         multiplayer.sendTo(previousHostId, {


### PR DESCRIPTION
## Summary
Added initialization of the `scoreAuthoritative` flag when the current instance becomes the host in a multiplayer session.

## Key Changes
- Set `scoreAuthoritative = true` when `isCurrentHost` condition is met, ensuring the host instance is marked as the authoritative source for score data

## Implementation Details
The flag is set at the beginning of the host initialization block, before other host-specific setup like resetting `lastEntityBroadcast` and handling previous host transitions. This ensures that score authority is established immediately when the current instance assumes the host role.

https://claude.ai/code/session_01VvR64X3778RX3K6fRgEv6Z