### PR TITLE
Immediately eject players from set piece zones on creation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1542,6 +1542,26 @@ async function main() {
     }
 
     setPieceManager.trigger(spType, teamTaking, ballFixedPos, zone, takerNetworkId, exclusionZone);
+
+    // Immediately eject any player already inside the zones at set piece creation.
+    if (multiplayer.isHost) {
+      const takerTeam = teamTaking;
+      const ejOtherBodies = [];
+      const ejOpposingBodies = [];
+      if (playerControls?.body) {
+        ejOtherBodies.push(playerControls.body);
+        if (localPlayerTeam !== takerTeam) ejOpposingBodies.push(playerControls.body);
+      }
+      for (const team of ['home', 'away']) {
+        for (const ai of (aiPlayers[team] ?? [])) {
+          if (ai.body && ai.networkId !== takerNetworkId) {
+            ejOtherBodies.push(ai.body);
+            ejOpposingBodies.push(ai.body);
+          }
+        }
+      }
+      setPieceManager.ejectBodiesNow(ejOtherBodies, ejOpposingBodies);
+    }
   }
 
   // Load additional level data (destructible props, etc.)
@@ -2432,7 +2452,8 @@ async function main() {
 
       // Split locally-simulated bodies into two groups:
       // - otherBodies: all non-taker bodies pushed out of the small taker zone
-      // - opposingBodies: only opposing team bodies pushed out of the larger exclusion zone
+      // - opposingBodies: non-taker bodies pushed out of the larger exclusion zone
+      //   (opposing team human player + all non-taker AI bots from both teams)
       const opposingTeam = sp.teamTaking === 'home' ? 'away' : 'home';
       const otherBodies = [];
       const opposingBodies = [];
@@ -2446,7 +2467,8 @@ async function main() {
         for (const ai of (aiPlayers[team] ?? [])) {
           if (ai.body && ai.body !== takerBody) {
             otherBodies.push(ai.body);
-            if (team === opposingTeam) opposingBodies.push(ai.body);
+            // All AI bots (both teams) stay out of the exclusion zone
+            opposingBodies.push(ai.body);
           }
         }
       }

--- a/setPiece.js
+++ b/setPiece.js
@@ -107,7 +107,7 @@ export class SetPieceManager {
       if (body) this._pushOutOfZone(body, a.zone);
     }
 
-    // Push opposing team bodies out of the larger exclusion zone
+    // Push non-taker bodies (both teams' bots + opposing human) out of the larger exclusion zone
     if (a.exclusionZone) {
       for (const body of opposingBodies) {
         if (body) this._pushOutOfZone(body, a.exclusionZone);
@@ -256,6 +256,20 @@ export class SetPieceManager {
     if (changed) {
       body.setTranslation({ x: nx, y: t.y, z: nz }, true);
       body.setLinvel({ x: vx, y: v.y, z: vz }, true);
+    }
+  }
+
+  // Immediately eject all bodies from their respective zones (call once on set piece creation).
+  ejectBodiesNow(otherBodies = [], opposingBodies = []) {
+    if (!this.active) return;
+    const a = this.active;
+    for (const body of otherBodies) {
+      if (body) this._pushOutOfZone(body, a.zone);
+    }
+    if (a.exclusionZone) {
+      for (const body of opposingBodies) {
+        if (body) this._pushOutOfZone(body, a.exclusionZone);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
This PR adds immediate ejection of players from set piece zones when a set piece is created, ensuring no players are trapped inside restricted areas at the moment of set piece initiation.

## Key Changes
- **app.js**: Added logic to immediately eject all players (human and AI) from set piece zones when the host creates a set piece. This includes:
  - Collecting all non-taker bodies (local player + all AI players from both teams)
  - Separating opposing team bodies for the larger exclusion zone
  - Calling the new `ejectBodiesNow()` method to push them out immediately
  
- **setPiece.js**: 
  - Added new `ejectBodiesNow()` method that performs immediate ejection of bodies from their respective zones (taker zone for other bodies, exclusion zone for opposing bodies)
  - Updated comments to clarify that the exclusion zone applies to non-taker bodies from both teams (all AI bots + opposing human player), not just the opposing team

## Implementation Details
- The immediate ejection only runs on the host to maintain consistency across multiplayer sessions
- All AI players from both teams are treated as "opposing bodies" for exclusion zone purposes, while only the opposing team's human player is included
- The ejection uses the existing `_pushOutOfZone()` mechanism to maintain consistency with the frame-by-frame enforcement logic

https://claude.ai/code/session_01HXgWyHYAKfVZzfwaFUcSFN