### PR TITLE
Adventure mode: per-round team configs, persistent progress, and tie/rollback rules

### DIFF
--- a/app.js
+++ b/app.js
@@ -530,6 +530,7 @@ async function main() {
       document.getElementById('adv-enemy-emoji').textContent = char.emoji;
       document.getElementById('adv-enemy-name').textContent = char.label;
       const config = getAdventureRoundConfig(safeRoundIdx);
+      setAdventureState({ active: true, round: safeRoundIdx, charKey: char.key, charModel: char.model, charEmoji: char.emoji, charLabel: char.label, config });
       document.querySelector('#adventure-round-overlay .adventure-vs-desc').textContent = `BOTS (${config.enemyBots}) VS YOU (${config.playerTeamSize})`;
       adventureRoundOverlay.classList.remove('hidden');
     }

--- a/app.js
+++ b/app.js
@@ -22,6 +22,41 @@ import { applyGlobalGravity } from "./gravity.js";
 import { getSpawnPosition } from './spawnUtils.js';
 
 const DEFAULT_CHARACTER_MODEL = "/models/old_man.fbx";
+const ADVENTURE_PROGRESS_KEY = 'adventureProgressRound';
+const ADVENTURE_IN_PROGRESS_KEY = 'adventureRoundInProgress';
+const ADVENTURE_ROUND_CONFIGS = [
+  { enemyBots: 1, playerTeamSize: 1 },
+  { enemyBots: 2, playerTeamSize: 2 },
+  { enemyBots: 2, playerTeamSize: 1 },
+  { enemyBots: 3, playerTeamSize: 2 },
+  { enemyBots: 4, playerTeamSize: 2 },
+  { enemyBots: 3, playerTeamSize: 1 },
+  { enemyBots: 4, playerTeamSize: 1 },
+];
+
+function clampAdventureRound(round) {
+  const parsed = Number.parseInt(round, 10);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.min(Math.max(parsed, 0), ADVENTURE_ROUND_CONFIGS.length - 1);
+}
+
+function getAdventureRoundConfig(roundIdx) {
+  return ADVENTURE_ROUND_CONFIGS[clampAdventureRound(roundIdx)] || ADVENTURE_ROUND_CONFIGS[0];
+}
+
+function getSavedAdventureRound() {
+  const savedRound = clampAdventureRound(localStorage.getItem(ADVENTURE_PROGRESS_KEY) || '0');
+  if (localStorage.getItem(ADVENTURE_IN_PROGRESS_KEY) !== '1') return savedRound;
+  const penaltyRound = clampAdventureRound(savedRound - 1);
+  localStorage.setItem(ADVENTURE_PROGRESS_KEY, String(penaltyRound));
+  localStorage.removeItem(ADVENTURE_IN_PROGRESS_KEY);
+  return penaltyRound;
+}
+
+function saveAdventureRound(roundIdx) {
+  localStorage.setItem(ADVENTURE_PROGRESS_KEY, String(clampAdventureRound(roundIdx)));
+}
+
 
 const clock = new THREE.Clock();
 const mixerClock = new THREE.Clock();
@@ -48,7 +83,7 @@ async function main() {
   });
 
   // ── Dashboard — choose Play Online vs Play Bots ─────────────────────────────
-  const { botsOnly, botsPerTeam, ballSizeMultiplier, gravityMultiplier, adventureMode, adventureCharModel } = await new Promise(resolve => {
+  const { botsOnly, botsPerTeam, ballSizeMultiplier, gravityMultiplier, adventureMode, adventureCharModel, adventureRoundConfig } = await new Promise(resolve => {
     const overlay = document.getElementById('dashboard-overlay');
     const settingsOverlay = document.getElementById('bots-settings-overlay');
     const onlineNumEl = document.getElementById('dashboard-online-num');
@@ -487,26 +522,33 @@ async function main() {
     }
 
     function showAdventureRound(roundIdx) {
-      const char = ADVENTURE_ORDER[roundIdx];
+      const safeRoundIdx = clampAdventureRound(roundIdx);
+      const char = ADVENTURE_ORDER[safeRoundIdx];
       if (!char) return;
       overlay.classList.add('hidden');
-      document.getElementById('adv-round-label').textContent = `ROUND ${roundIdx + 1} / ${ADVENTURE_ORDER.length}`;
+      document.getElementById('adv-round-label').textContent = `ROUND ${safeRoundIdx + 1} / ${ADVENTURE_ORDER.length}`;
       document.getElementById('adv-enemy-emoji').textContent = char.emoji;
       document.getElementById('adv-enemy-name').textContent = char.label;
+      const config = getAdventureRoundConfig(safeRoundIdx);
+      document.querySelector('#adventure-round-overlay .adventure-vs-desc').textContent = `BOTS (${config.enemyBots}) VS YOU (${config.playerTeamSize})`;
       adventureRoundOverlay.classList.remove('hidden');
     }
 
     function startAdventureRound(roundIdx) {
-      const char = ADVENTURE_ORDER[roundIdx];
-      setAdventureState({ active: true, round: roundIdx, charKey: char.key, charModel: char.model, charEmoji: char.emoji, charLabel: char.label });
+      const safeRoundIdx = clampAdventureRound(roundIdx);
+      const char = ADVENTURE_ORDER[safeRoundIdx];
+      const config = getAdventureRoundConfig(safeRoundIdx);
+      saveAdventureRound(safeRoundIdx);
+      localStorage.setItem(ADVENTURE_IN_PROGRESS_KEY, '1');
+      setAdventureState({ active: true, round: safeRoundIdx, charKey: char.key, charModel: char.model, charEmoji: char.emoji, charLabel: char.label, config });
       sessionStorage.setItem('skipToGame', '1');
       unsubCount();
       adventureRoundOverlay.classList.add('hidden');
-      resolve({ botsOnly: true, botsPerTeam: 3, ballSizeMultiplier: 1.0, gravityMultiplier: 1.0, adventureMode: true, adventureCharModel: char.model });
+      resolve({ botsOnly: true, botsPerTeam: 3, ballSizeMultiplier: 1.0, gravityMultiplier: 1.0, adventureMode: true, adventureCharModel: char.model, adventureRoundConfig: config });
     }
 
     document.getElementById('btn-adventure-mode').addEventListener('click', () => {
-      showAdventureRound(0);
+      showAdventureRound(getSavedAdventureRound());
     });
 
     document.getElementById('adv-start-round').addEventListener('click', () => {
@@ -527,12 +569,15 @@ async function main() {
       const nextRound = (state?.round ?? 0) + 1;
       if (nextRound >= ADVENTURE_ORDER.length) {
         // All rounds complete
+        saveAdventureRound(ADVENTURE_ORDER.length - 1);
+        localStorage.removeItem(ADVENTURE_IN_PROGRESS_KEY);
         setAdventureState(null);
         adventureWinOverlay.classList.add('hidden');
         overlay.classList.remove('hidden');
       } else {
         const nextChar = ADVENTURE_ORDER[nextRound];
-        setAdventureState({ active: true, round: nextRound, charKey: nextChar.key, charModel: nextChar.model, charEmoji: nextChar.emoji, charLabel: nextChar.label });
+        saveAdventureRound(nextRound);
+        setAdventureState({ active: true, round: nextRound, charKey: nextChar.key, charModel: nextChar.model, charEmoji: nextChar.emoji, charLabel: nextChar.label, config: getAdventureRoundConfig(nextRound) });
         adventureWinOverlay.classList.add('hidden');
         showAdventureRound(nextRound);
       }
@@ -546,9 +591,10 @@ async function main() {
 
     // Adventure lose overlay buttons
     document.getElementById('adv-try-again').addEventListener('click', () => {
-      setAdventureState({ active: true, round: 0 });
+      const state = getAdventureState();
+      const retryRound = clampAdventureRound(state?.round ?? getSavedAdventureRound());
       adventureLoseOverlay.classList.add('hidden');
-      showAdventureRound(0);
+      showAdventureRound(retryRound);
     });
 
     document.getElementById('adv-lose-quit').addEventListener('click', () => {
@@ -562,12 +608,14 @@ async function main() {
     if (returningAdventureState?.active && sessionStorage.getItem('adventureResult')) {
       const result = sessionStorage.getItem('adventureResult');
       sessionStorage.removeItem('adventureResult');
-      const roundIdx = returningAdventureState.round;
+      const roundIdx = clampAdventureRound(returningAdventureState.round);
       const char = ADVENTURE_ORDER[roundIdx];
 
       overlay.classList.add('hidden');
 
+      localStorage.removeItem(ADVENTURE_IN_PROGRESS_KEY);
       if (result === 'win') {
+        saveAdventureRound(Math.min(roundIdx + 1, ADVENTURE_ORDER.length - 1));
         document.getElementById('adv-win-text').textContent = `YOU DEFEATED THE ${char?.label || ''}!`;
         document.getElementById('adv-unlocked-emoji').textContent = char?.emoji || '';
         const isLastRound = roundIdx >= ADVENTURE_ORDER.length - 1;
@@ -576,7 +624,14 @@ async function main() {
           document.getElementById('adv-win-text').textContent = 'YOU BEAT ADVENTURE MODE!';
         }
         adventureWinOverlay.classList.remove('hidden');
+      } else if (result === 'draw') {
+        saveAdventureRound(roundIdx);
+        showAdventureRound(roundIdx);
       } else {
+        const previousRound = clampAdventureRound(roundIdx - 1);
+        saveAdventureRound(previousRound);
+        setAdventureState({ active: true, round: previousRound, config: getAdventureRoundConfig(previousRound) });
+        document.querySelector('#adventure-lose-overlay .adventure-result-text').innerHTML = 'YOU LOST — TRY AGAIN FROM<br>THE PREVIOUS ROUND.';
         adventureLoseOverlay.classList.remove('hidden');
       }
     }
@@ -1504,7 +1559,7 @@ async function main() {
       if (adventureMode) {
         const advState = (() => { try { return JSON.parse(sessionStorage.getItem('adventureState') || 'null'); } catch { return null; } })();
         const playerWon = winningTeam === localPlayerTeam;
-        const result = playerWon ? 'win' : 'loss';
+        const result = winningTeam === null ? 'draw' : playerWon ? 'win' : 'loss';
 
         if (playerWon && advState?.charKey) {
           try { await unlockCharacterFree(`char_${advState.charKey}`); } catch { /* best-effort */ }
@@ -1895,8 +1950,11 @@ async function main() {
   function countNeededAIByTeam() {
     const realCounts = countRealPlayersByTeam();
     if (adventureMode) {
-      // Adventure: player alone on home, 3 bots on away
-      return { home: 0, away: Math.max(0, 3 - realCounts.away) };
+      const config = adventureRoundConfig || getAdventureRoundConfig(0);
+      return {
+        home: Math.max(0, config.playerTeamSize - realCounts.home),
+        away: Math.max(0, config.enemyBots - realCounts.away)
+      };
     }
     return {
       home: Math.max(0, MIN_PLAYERS_PER_TEAM - realCounts.home),

--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@
       <div class="adventure-vs-block">
         <div class="adventure-vs-emoji" id="adv-enemy-emoji"></div>
         <div class="adventure-vs-name" id="adv-enemy-name"></div>
-        <div class="adventure-vs-desc">YOU (1) VS BOTS (3)</div>
+        <div class="adventure-vs-desc">BOTS (1) VS YOU (1)</div>
         <div class="adventure-vs-hint">WIN TO UNLOCK THIS CHARACTER!</div>
       </div>
       <button class="arcade-btn arcade-btn-green" id="adv-start-round">▶ START ROUND</button>
@@ -399,7 +399,7 @@
   <div id="adventure-lose-overlay" class="arcade-overlay hidden">
     <div class="arcade-panel adventure-panel">
       <div class="arcade-title" style="font-size:clamp(12px,2.5vw,16px);color:#ff4444">💀 DEFEATED!</div>
-      <div class="adventure-result-text">YOU LOST — TRY AGAIN FROM<br>THE BEGINNING?</div>
+      <div class="adventure-result-text">YOU LOST — TRY AGAIN FROM<br>THE PREVIOUS ROUND.</div>
       <div class="adventure-result-buttons">
         <button class="arcade-btn arcade-btn-yellow" id="adv-try-again">↺ TRY AGAIN</button>
         <button class="arcade-btn arcade-btn-dim" id="adv-lose-quit">🏠 DASHBOARD</button>


### PR DESCRIPTION
### Motivation
- Implement the requested Adventure Mode sequence (1v1, 2v2, 2v1, 3v2, 4v2, 3v1, 4v1) and make round progression resilient across sessions.
- Prevent players from exploiting mid-game quits to stay on a round by applying a rollback penalty when they leave during a round.

### Description
- Add `ADVENTURE_ROUND_CONFIGS`, `clampAdventureRound`, `getAdventureRoundConfig`, `saveAdventureRound`, and `getSavedAdventureRound` to manage per-round bot/player counts and persisted progress in `localStorage` (keys `adventureProgressRound` and `adventureRoundInProgress`).
- Update pre-round UI via `showAdventureRound` to display the dynamic `BOTS (N) VS YOU (M)` matchup and to resume from the saved round using `getSavedAdventureRound`.
- Persist in-progress state on `startAdventureRound` and propagate the selected round config into the resolved game options so `countNeededAIByTeam` spawns the configured number of bots and player-side helpers during Adventure Mode.
- Change end-of-round handling so wins advance progress, ties replay the same round, losses roll back to the previous round, and mid-game exits apply a one-round penalty; also update the lose overlay copy in `index.html`.

### Testing
- Ran `node --check app.js` to validate the modified module and it succeeded.
- Built the app with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56914104548331801d44f98e4ec94f)