### PR TITLE
Add sprint and desktop slide controls

### DIFF
--- a/app.js
+++ b/app.js
@@ -1850,17 +1850,14 @@ async function main() {
   document.addEventListener('mousedown', _startMusic, { once: true });
   document.addEventListener('touchstart', _startMusic, { once: true });
 
-  window.localHealth = 100;
-
-  const healthFill = document.getElementById('health-fill');
-  function updateHealthUI() {
-    if (healthFill) {
-      healthFill.style.width = `${window.localHealth}%`;
+  const sprintFill = document.getElementById('sprint-fill');
+  function updateSprintUI() {
+    if (sprintFill) {
+      const sprintPercent = playerControls?.getSprintPercent?.() ?? 0;
+      sprintFill.style.width = `${sprintPercent}%`;
     }
   }
-  updateHealthUI();
-
-  let playerDead = false;
+  updateSprintUI();
 
   const projectiles = [];
 
@@ -2181,8 +2178,7 @@ async function main() {
   }
 
   function respawnPlayer() {
-    window.localHealth = 100;
-    updateHealthUI();
+    updateSprintUI();
     const spawn = getTeamSpawnPosition(localPlayerTeam);
     playerModel.position.set(spawn.x, spawn.y, spawn.z);
     playerControls.playerX = spawn.x;
@@ -2196,7 +2192,6 @@ async function main() {
     }
     playerControls.velocity.set(0, 0, 0);
     playerControls.enabled = true;
-    playerDead = false;
     const actions = playerModel.userData.actions;
     const current = playerModel.userData.currentAction;
     actions?.[current]?.fadeOut(0.2);
@@ -2211,18 +2206,20 @@ async function main() {
     shoot: () => playerControls.triggerFire()
   });
 
-  const rollButton = document.getElementById('roll-button');
-  if (rollButton) {
-    const doRoll = (e) => {
+  const bindActionButton = (id, action) => {
+    const button = document.getElementById(id);
+    if (!button) return;
+    const handler = (e) => {
       e.preventDefault();
-      if (!playerControls.enabled || playerControls.isInWater || playerControls.currentSpecialAction) return;
-      playerControls.slideMomentum.copy(playerControls.lastMoveDirection).multiplyScalar(1.4);
-      playerControls.playAction('runningKick');
-      playerControls.audioManager?.playAttack();
+      action();
     };
-    rollButton.addEventListener('touchstart', doRoll, { passive: false });
-    rollButton.addEventListener('mousedown', doRoll);
-  }
+    button.addEventListener('touchstart', handler, { passive: false });
+    button.addEventListener('mousedown', handler);
+  };
+
+  bindActionButton('roll-button', () => playerControls.triggerRoll());
+  bindActionButton('slide-button', () => playerControls.triggerSlide());
+  bindActionButton('sprint-button', () => playerControls.triggerSprint());
 
   let localStream = null;
   let micActive = false;
@@ -2551,20 +2548,7 @@ async function main() {
       lastControlSend = now;
     }
 
-    updateHealthUI();
-    if (window.localHealth <= 0 && !playerDead) {
-      playerDead = true;
-      playerControls.enabled = false;
-      const actions = playerModel.userData.actions;
-      const current = playerModel.userData.currentAction;
-      const die = actions?.die;
-      if (die) {
-        actions[current]?.fadeOut(0.2);
-        die.reset().fadeIn(0.2).play();
-        playerModel.userData.currentAction = 'die';
-      }
-      showGameOver();
-    }
+    updateSprintUI();
 
     const mixerDelta = mixerClock.getDelta();
 

--- a/characters/MonsterCharacter.js
+++ b/characters/MonsterCharacter.js
@@ -142,12 +142,11 @@ export function updateMonster(monster, deltaTime, playerModel, otherPlayers) {
         const dist = monster.position.distanceTo(player.model.position);
         if (dist < 3.2) {
           if (player.id === 'local' && !window.playerControls.isKnocked) {
-            window.localHealth = Math.max(0, window.localHealth - 10);
             if (window.playerControls) {
               const impulse = monster.userData.direction.clone().multiplyScalar(0.17);
               window.playerControls.applyKnockback(impulse);
             }
-            console.log(`👹 Monster attacks you! Distance: ${dist.toFixed(2)} | Health: ${window.localHealth.toFixed(1)}`);
+            console.log(`👹 Monster attacks you! Distance: ${dist.toFixed(2)}`);
           } else if (player.id !== 'local') {
             const op = otherPlayers[player.id];
             if (op) {

--- a/controls.js
+++ b/controls.js
@@ -7,6 +7,8 @@ import { getSpawnPosition } from './spawnUtils.js';
 // Movement constants
 const SPEED = 5;
 const SWIM_SPEED = 2;
+const SPRINT_MULTIPLIER = 1.8;
+const SPRINT_DURATION_MS = 500;
 const JUMP_FORCE = 5;
 const PLAYER_RADIUS = 0.3;
 const PLAYER_HALF_HEIGHT = 0.6;
@@ -54,6 +56,7 @@ export class PlayerControls {
     this.currentSpecialAction = null;
     this.runningKickTimer = null;
     this.runningKickOriginalY = 0;
+    this.sprintEndTime = 0;
     
     // Mobile control variables
     this.joystick = null;
@@ -321,15 +324,7 @@ export class PlayerControls {
       slideButton.innerText = 'SLIDE';
       actionContainer.appendChild(slideButton);
       slideButton.addEventListener('touchstart', (event) => {
-        if (!this.enabled || this.isInWater || this.currentSpecialAction) return;
-        const vel = this.body?.linvel();
-        const hSpeed = vel ? Math.hypot(vel.x, vel.z) : 0;
-        const speedRatio = Math.min(hSpeed / SPEED, 1);
-        const magnitude = 0.8 + speedRatio * 1.8;
-        this.slideMomentumDecay = 0.880 + speedRatio * 0.060;
-        this.slideMomentum.copy(this.lastMoveDirection).multiplyScalar(magnitude);
-        this.playAction('slide');
-        this.audioManager?.playSlide();
+        this.triggerSlide();
         event.preventDefault();
       });
     }
@@ -387,20 +382,11 @@ export class PlayerControls {
         this.playAction('mmaKick');
         this.audioManager?.playAttack();
       } else if (key === 'r') {
-        if (this.isInWater) return;
-        this.slideMomentum.copy(this.lastMoveDirection).multiplyScalar(1.4);
-        this.playAction('runningKick');
-        this.audioManager?.playRoll();
+        this.triggerRoll();
       } else if (key === 'z') {
-        if (this.isInWater || this.currentSpecialAction) return;
-        const vel = this.body?.linvel();
-        const hSpeed = vel ? Math.hypot(vel.x, vel.z) : 0;
-        const speedRatio = Math.min(hSpeed / SPEED, 1);
-        const magnitude = 0.8 + speedRatio * 1.8;
-        this.slideMomentumDecay = 0.880 + speedRatio * 0.060;
-        this.slideMomentum.copy(this.lastMoveDirection).multiplyScalar(magnitude);
-        this.playAction('slide');
-        this.audioManager?.playSlide();
+        this.triggerSlide();
+      } else if (key === 'shift') {
+        this.triggerSprint();
       } else if (key === 'g') {
         if (this.grabbedTarget) {
           this.releaseGrab();
@@ -657,7 +643,7 @@ export class PlayerControls {
         this.playerModel.userData.currentAction = 'idle';
       }
     } else {
-      const speed = this.isInWater ? SWIM_SPEED : SPEED;
+      const speed = this.getCurrentSpeed();
       this.body.setLinvel({ x: movement.x * speed, y: vel.y, z: movement.z * speed }, true);
       }
     const newX = t.x;
@@ -876,6 +862,39 @@ export class PlayerControls {
   
   getPlayerModel() {
     return this.playerModel;
+  }
+
+  triggerRoll() {
+    if (!this.enabled || this.isInWater || this.currentSpecialAction) return;
+    this.slideMomentum.copy(this.lastMoveDirection).multiplyScalar(1.4);
+    this.playAction('runningKick');
+    this.audioManager?.playRoll();
+  }
+
+  triggerSlide() {
+    if (!this.enabled || this.isInWater || this.currentSpecialAction) return;
+    const vel = this.body?.linvel();
+    const hSpeed = vel ? Math.hypot(vel.x, vel.z) : 0;
+    const speedRatio = Math.min(hSpeed / SPEED, 1);
+    const magnitude = 0.8 + speedRatio * 1.8;
+    this.slideMomentumDecay = 0.880 + speedRatio * 0.060;
+    this.slideMomentum.copy(this.lastMoveDirection).multiplyScalar(magnitude);
+    this.playAction('slide');
+    this.audioManager?.playSlide();
+  }
+
+  triggerSprint() {
+    if (!this.enabled || this.isInWater) return;
+    this.sprintEndTime = performance.now() + SPRINT_DURATION_MS;
+  }
+
+  getSprintPercent() {
+    return Math.max(0, Math.min(100, ((this.sprintEndTime - performance.now()) / SPRINT_DURATION_MS) * 100));
+  }
+
+  getCurrentSpeed() {
+    const baseSpeed = this.isInWater ? SWIM_SPEED : SPEED;
+    return this.getSprintPercent() > 0 ? baseSpeed * SPRINT_MULTIPLIER : baseSpeed;
   }
 
   /**

--- a/index.html
+++ b/index.html
@@ -16,11 +16,13 @@
     <div class="crosshair"></div>
   </div>
   <div id="interaction-tooltip" class="interaction-tooltip"></div>
-  <div id="health-bar"><div id="health-fill"></div></div>
+  <div id="sprint-bar"><div id="sprint-fill"></div></div>
   <div id="action-buttons">
     <button id="mobile-action-toggle" class="action-button mobile-only" aria-expanded="false" aria-label="Toggle actions">⋯</button>
     <button id="voice-button" class="action-button mobile-action">Unmute</button>
     <button id="roll-button" class="action-button mobile-action">ROLL</button>
+    <button id="slide-button" class="action-button mobile-action">SLIDE</button>
+    <button id="sprint-button" class="action-button mobile-action">SPRINT</button>
   </div>
   
   <!-- Follow Ball Camera Button -->

--- a/styles.css
+++ b/styles.css
@@ -250,7 +250,7 @@ body {
   cursor: pointer;
 }
 
-#health-bar {
+#sprint-bar {
   position: absolute;
   top: 10px;
   left: 10px;
@@ -261,10 +261,10 @@ body {
   z-index: 1000;
 }
 
-#health-fill {
+#sprint-fill {
   height: 100%;
-  background: #0f0;
-  width: 100%;
+  background: #27d9ff;
+  width: 0%;
 }
 
 #ammo-display {


### PR DESCRIPTION
### Motivation
- Provide desktop parity with mobile by exposing the `SLIDE` action and adding a `SPRINT` mechanic to both desktop and mobile UIs. 
- Replace the top health UI with a sprint meter so the UI reflects sprinting instead of health tracking.

### Description
- Replaced the top health bar markup and CSS (`#health-bar` / `#health-fill`) with a sprint meter (`#sprint-bar` / `#sprint-fill`) and styled it to start empty. (`index.html`, `styles.css`).
- Added `SLIDE` and `SPRINT` buttons next to the existing `ROLL` button in the action button area for both desktop and mobile flows. (`index.html`, `app.js`).
- Implemented sprint functionality in `controls.js` with constants `SPRINT_MULTIPLIER` and `SPRINT_DURATION_MS`, sprint state tracking (`sprintEndTime`), and helper methods `triggerSprint()`, `getSprintPercent()`, and `getCurrentSpeed()`; movement now uses `getCurrentSpeed()` so sprint temporarily increases speed for 500ms. (`controls.js`).
- Factored shared action triggers into `triggerRoll()` / `triggerSlide()` methods and wired buttons to call these methods via a reusable `bindActionButton` helper for both `touchstart` and `mousedown` events. (`controls.js`, `app.js`).
- Removed local decrementing of `window.localHealth` when monsters hit the player while preserving knockback behavior. (`characters/MonsterCharacter.js`).

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite built the app; bundle-size warnings were reported but build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a569fe3933c8331a104a3f9f69a4225)