### PR TITLE
Refactor root motion stripping and update player animations

### DIFF
--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -109,15 +109,13 @@ function clipWithExistingTargetsOnly(clip, root) {
   return new THREE.AnimationClip(clip.name, clip.duration, tracks);
 }
 
-function stripRootTracks(clip, rootName) {
-  const blocked = new Set([
-    `${rootName}.position`,
-    `${rootName}.quaternion`,
-    `${rootName}.scale`,
-    `${rootName}.matrix`,
-    `${rootName}.visible`,
-  ]);
-  const tracks = clip.tracks.filter(t => !blocked.has(t.name));
+function stripRootMotion(clip) {
+  // Remove position tracks from hip/root bones to prevent character from drifting
+  const tracks = clip.tracks.filter(t => {
+    if (!t.name.endsWith('.position')) return true;
+    const boneName = t.name.split('.')[0].toLowerCase();
+    return !boneName.includes('hip') && !boneName.includes('root') && boneName !== 'armature';
+  });
   return new THREE.AnimationClip(clip.name, clip.duration, tracks);
 }
 
@@ -248,10 +246,10 @@ export function createPlayerModel(
             idle: 'Breathing Idle.fbx',
             walk: 'Old Man Walk.fbx',
             run: 'Drunk Run Forward.fbx',
-            jump: 'Joyful Jump.fbx',
+            jump: 'Soccer Header.fbx',
             hit: 'Flying Back Death.fbx',
             mutantPunch: 'Mutant Punch.fbx',
-            mmaKick: 'Mma Kick.fbx',
+            mmaKick: 'Running Kick.fbx',
             runningKick: 'Stand To Roll.fbx',
             slide: 'Female Laying Pose.fbx',
             hurricaneKick: 'Hurricane Kick.fbx',
@@ -261,6 +259,8 @@ export function createPlayerModel(
             swim: 'Swimming.fbx',
             sit: 'Sitting Rubbing Arm.fbx',
             throwIn: 'Throw In.fbx',
+            bicycleKick: 'Bicycle Kick.fbx',
+            farKick: 'Far Kick.fbx',
           };
 
           const promises = Object.entries(animationFiles).map(([name, file]) => {
@@ -268,14 +268,10 @@ export function createPlayerModel(
               fbxLoader.load(
                 `/models/animations/${encodeURIComponent(file)}`,
                 (anim) => {
-                  const clip = anim.animations[0];
-                  // const rootName = model.name || 'Root';
-                  // const src = anim.animations[0];
-                  // const clean = stripRootTracks(src, rootName);
-                  // const action = mixer.clipAction(clean);
+                  const clip = stripRootMotion(anim.animations[0]);
                   const action = mixer.clipAction(clip);
                   if (
-                    ['jump', 'hit', 'mutantPunch', 'mmaKick', 'runningKick', 'hurricaneKick', 'projectile', 'die', 'throwIn'].includes(name)
+                    ['hit', 'mutantPunch', 'mmaKick', 'runningKick', 'hurricaneKick', 'projectile', 'die', 'throwIn', 'bicycleKick', 'farKick'].includes(name)
                   ) {
                     action.loop = THREE.LoopOnce;
                     action.clampWhenFinished = true;


### PR DESCRIPTION
## Summary
This PR refactors the animation track filtering logic and updates the player model's animation file mappings to use different animation assets and improve root motion handling.

## Key Changes
- **Refactored `stripRootTracks()` to `stripRootMotion()`**: Simplified the function to specifically target position tracks from hip/root bones rather than blocking multiple track types. This prevents character drift during animations by filtering based on bone name patterns ('hip', 'root', 'armature') instead of a hardcoded set of track types.

- **Updated animation file mappings**:
  - Changed `jump` animation from 'Joyful Jump.fbx' to 'Soccer Header.fbx'
  - Changed `mmaKick` animation from 'Mma Kick.fbx' to 'Running Kick.fbx'
  - Added two new animations: `bicycleKick` ('Bicycle Kick.fbx') and `farKick` ('Far Kick.fbx')

- **Applied root motion stripping to all animations**: The `stripRootMotion()` function is now called on all loaded animations during initialization, ensuring consistent handling of root motion across the board.

- **Updated loop configuration**: Added 'bicycleKick' and 'farKick' to the list of animations that should use `LoopOnce` with `clampWhenFinished`, and removed 'jump' from this list (since it now uses a different animation asset).

## Implementation Details
The new `stripRootMotion()` approach is more flexible and maintainable than the previous hardcoded track list, as it dynamically identifies root/hip bones by name pattern matching rather than requiring explicit configuration per bone name.

https://claude.ai/code/session_019HDf4vQvua1vQEnQtZ9PEg