### PR TITLE
Add lob shot mechanic to farKick attack

### DIFF
--- a/melee.js
+++ b/melee.js
@@ -5,7 +5,7 @@ const ATTACKS = {
   hurricaneKick: { damage: 15, range: 2.0, hitTime: 200, hitWindow: 200 },
   mmaKick: { damage: 12, range: 1.7, hitTime: 175, hitWindow: 150 },
   slide: { damage: 0, range: 1.8, hitTime: 50, hitWindow: 3000, ballForce: 0.55 },
-  farKick: { damage: 8, range: 1.9, hitTime: 250, hitWindow: 200, ballForce: 0.9 },
+  farKick: { damage: 8, range: 1.9, hitTime: 250, hitWindow: 200, ballForce: 0.9, lob: true },
   bicycleKick: { damage: 10, range: 2.2, hitTime: 450, hitWindow: 300 },
 };
 
@@ -61,10 +61,18 @@ export function updateMeleeAttacks({ playerModel, otherPlayers, audioManager }) 
             const dir = new THREE.Vector3()
               .subVectors(ballVec, attacker.model.position)
               .normalize();
-            dir.y = Math.max(dir.y, 0.2);
-            dir.normalize();
-            const force = cfg.ballForce ?? 0.3;
-            window.soccerBall.applyImpulse({ x: dir.x * force, y: dir.y * force, z: dir.z * force });
+            let impulse;
+            if (cfg.lob) {
+              // Lob: steep upward arc, short horizontal distance
+              const lobForce = cfg.ballForce ?? 0.9;
+              impulse = { x: dir.x * lobForce * 0.25, y: lobForce * 0.85, z: dir.z * lobForce * 0.25 };
+            } else {
+              dir.y = Math.max(dir.y, 0.2);
+              dir.normalize();
+              const force = cfg.ballForce ?? 0.3;
+              impulse = { x: dir.x * force, y: dir.y * force, z: dir.z * force };
+            }
+            window.soccerBall.applyImpulse(impulse);
             audioManager?.playBallKick();
           }
         }


### PR DESCRIPTION
## Summary
Implemented a new lob shot mechanic for the `farKick` attack that produces a steep upward arc with reduced horizontal distance, providing more tactical variety in attacking options.

## Key Changes
- Added `lob: true` property to the `farKick` attack configuration
- Refactored ball impulse calculation to support two distinct shot types:
  - **Lob shots**: Steep upward trajectory (85% vertical force) with minimal horizontal spread (25% of horizontal force)
  - **Standard shots**: Original behavior with directional force application and minimum upward angle
- Impulse calculation now conditionally branches based on the `lob` property, allowing future attacks to use either shot type

## Implementation Details
- Lob shots use a fixed high vertical component (0.85 × ballForce) while reducing horizontal components to 25% of their original magnitude
- Standard shots maintain the previous behavior: normalized direction with a minimum 0.2 y-component
- The `ballForce` parameter defaults to 0.9 for lobs and 0.3 for standard shots, providing appropriate trajectory characteristics for each shot type

https://claude.ai/code/session_01RFNEi467fuTWqFsKYFegCF