### PR TITLE
Add Game settings tab with Leave Game button

### DIFF
--- a/app.js
+++ b/app.js
@@ -3165,6 +3165,10 @@ async function main() {
     if (e.target === overlay) overlay.style.display = 'none';
   });
 
+  document.getElementById('leave-game-btn').addEventListener('click', () => {
+    window.location.reload();
+  });
+
   (function() {
     const originalLog = console.log;
     console.log = function(...args) {

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       <div id="settings-side-tabs">
         <button class="side-tab-btn active" data-tab="audio">Audio</button>
         <button class="side-tab-btn" data-tab="multiplayer">Multiplayer</button>
+        <button class="side-tab-btn" data-tab="game">Game</button>
       </div>
       <div id="settings-tab-body">
         <div id="tab-audio" class="side-tab-content">
@@ -52,6 +53,12 @@
 
         <div id="tab-multiplayer" class="side-tab-content" style="display:none">
           <div id="teams-table-container"></div>
+        </div>
+
+        <div id="tab-game" class="side-tab-content" style="display:none">
+          <div class="audio-settings-section">
+            <button id="leave-game-btn" class="arcade-btn arcade-btn-red">Leave Game</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Added a new "Game" tab to the settings panel that allows players to leave the current game session.

## Key Changes
- Added a new "Game" tab button to the settings side navigation menu
- Created a new "Game" settings tab content section with a "Leave Game" button styled as a red arcade button
- Implemented click handler for the "Leave Game" button that reloads the page to exit the game

## Implementation Details
- The new tab follows the existing tab structure pattern used for Audio and Multiplayer tabs
- The "Leave Game" button uses the existing `arcade-btn` and `arcade-btn-red` CSS classes for consistent styling
- Page reload via `window.location.reload()` is used to cleanly exit the game session

https://claude.ai/code/session_015u77FMouNrnQo3nz8pqLiN