### PR TITLE
Improve player camera positioning and goal kick spawn logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -2383,7 +2383,7 @@ async function main() {
         spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
         spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
       } else if (spType === 'goalKick') {
-        spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
+        spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * 3;
       }
       playerControls.body.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
       playerControls.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
@@ -2422,7 +2422,7 @@ async function main() {
           spawnX = ballFixedPos.x + Math.sign(ballFixedPos.x) * OFFSET;
           spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
         } else if (spType === 'goalKick') {
-          spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * OFFSET;
+          spawnZ = ballFixedPos.z + Math.sign(ballFixedPos.z) * 3;
         }
         takerAIBody.setTranslation({ x: spawnX, y: sy, z: spawnZ }, true);
         takerAIBody.setLinvel({ x: 0, y: 0, z: 0 }, true);

--- a/controls.js
+++ b/controls.js
@@ -104,12 +104,16 @@ export class PlayerControls {
       world.createCollider(colDesc, this.body);
     }
 
-    // Set camera to third-person perspective
-    this.camera.position.set(this.playerX, this.playerY + 2, this.playerZ + 5);
+    // Face toward center of field: if player is in -z half, yaw = π (face +z)
+    this.yaw = this.playerZ < 0 ? Math.PI : 0;
+
+    // Camera offset in local space (behind player, applied after yaw rotation)
+    this.cameraOffset = new THREE.Vector3(0, 1, 5);
+
+    // Set camera to third-person perspective, behind the player facing center
+    const initZOff = 5 * Math.cos(this.yaw); // +5 when facing -z, -5 when facing +z
+    this.camera.position.set(this.playerX, this.playerY + 2, this.playerZ + initZOff);
     this.camera.lookAt(this.playerX, this.playerY + 1, this.playerZ);
-    // Store the initial camera offset (relative to player's target position)
-    this.cameraOffset = new THREE.Vector3();
-    this.cameraOffset.copy(this.camera.position).sub(new THREE.Vector3(this.playerX, this.playerY + 1, this.playerZ));
 
     // Initialize controls based on device
     this.initializeControls();


### PR DESCRIPTION
## Summary
This PR refines the camera system to properly orient players toward the center of the field and adjusts goal kick spawn positioning for better gameplay mechanics.

## Key Changes

- **Camera initialization with field-aware orientation**: Players now spawn facing toward the center of the field based on which half they're in. If spawning in the -z half, the player faces +z (π radians), otherwise faces 0 radians.

- **Camera offset refactoring**: Replaced the computed camera offset calculation with an explicit local-space offset vector (0, 1, 5) that's applied after yaw rotation, making the camera behavior more predictable and maintainable.

- **Goal kick spawn distance adjustment**: Changed goal kick spawn offset from `OFFSET` constant to a fixed value of `3` units. This provides more consistent positioning for goal kick scenarios compared to the variable offset used for other set pieces.

## Implementation Details

The camera system now uses a yaw-based approach where the initial Z offset is calculated as `5 * Math.cos(this.yaw)`, ensuring the camera stays behind the player regardless of their facing direction. This replaces the previous method of computing the offset from the difference between camera and player positions.

The goal kick spawn logic is simplified by using a hardcoded distance of 3 units instead of the `OFFSET` variable, which appears to be more appropriate for the specific geometry of goal kick scenarios.

https://claude.ai/code/session_01U3nzVrVCaYtJZdMuZRHgd5