### PR TITLE
Update dashboard/settings UI: grid layout, gear icon, inline character picker, move shop & audio sliders

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ import { getTerrainHeight } from './water.js';
 import { Multiplayer, subscribeOnlineCount } from './peerConnection.js';
 import { PlayerControls } from './controls.js';
 import { getCookie, setCookie } from './utils.js';
-import { initLogin, getSession, clearSession, getUser, updateUserDisplayName, getUserUpgrades, purchaseUpgrade, unlockCharacterFree, showCharacterSelect, updateUserCharacter, CHARACTERS, ADVENTURE_ORDER, changePin, deleteAccount } from './login.js';
+import { initLogin, getSession, clearSession, getUser, updateUserDisplayName, getUserUpgrades, purchaseUpgrade, unlockCharacterFree, updateUserCharacter, CHARACTERS, ADVENTURE_ORDER, changePin, deleteAccount } from './login.js';
 import { spawnProjectile, updateProjectiles } from './projectiles.js';
 import { updateMeleeAttacks } from './melee.js';
 import { LevelLoader } from './levelLoader.js';
@@ -274,12 +274,18 @@ async function main() {
     // ── Profile button ──────────────────────────────────────────────────────────
     let currentPlayerName = playerName;
 
-    function openProfileOverlay() {
+    async function openProfileOverlay() {
       const profileOverlay = document.getElementById('profile-overlay');
       document.getElementById('profile-name-input').value = currentPlayerName;
       document.getElementById('profile-name-error').classList.add('hidden');
       document.getElementById('profile-name-ok').classList.add('hidden');
+      profileCharIndex = Math.max(0, CHARACTERS.findIndex(c => c.model === characterModel));
+      renderProfileCharacterPicker(false);
       profileOverlay.classList.remove('hidden');
+      try {
+        profileUnlockedKeys = await getUserUpgrades(getSession()) || {};
+        renderProfileCharacterPicker(false);
+      } catch { /* keep current unlock display */ }
     }
 
     document.getElementById('btn-profile').addEventListener('click', openProfileOverlay);
@@ -336,21 +342,47 @@ async function main() {
       }
     });
 
-    // Change character from profile
-    document.getElementById('btn-profile-char').addEventListener('click', () => {
-      const profileOverlay = document.getElementById('profile-overlay');
-      const sessionUser = getSession();
-      profileOverlay.classList.add('hidden');
-      // Reuse the character select screen; pass a dummy overlay that won't be shown
-      const dummyOverlay = document.createElement('div');
-      showCharacterSelect(dummyOverlay, sessionUser, ({ character }) => {
-        setCookie('characterModel', character, 365);
-        if (character !== characterModel) {
-          characterModel = character;
+    let profileCharIndex = Math.max(0, CHARACTERS.findIndex(c => c.model === characterModel));
+    let profileUnlockedKeys = {};
+
+    function profileCharacterUnlocked(character) {
+      return character.free || !!profileUnlockedKeys[`char_${character.key}`];
+    }
+
+    async function renderProfileCharacterPicker(saveChoice = false) {
+      const chosen = CHARACTERS[profileCharIndex];
+      const statusEl = document.getElementById('profile-char-save-status');
+      document.getElementById('profile-char-emoji').textContent = chosen.emoji;
+      const locked = !profileCharacterUnlocked(chosen);
+      document.getElementById('profile-char-lock-info').classList.toggle('hidden', !locked);
+      if (statusEl) statusEl.textContent = locked ? 'LOCKED' : '';
+      if (locked || !saveChoice) return;
+
+      if (statusEl) statusEl.textContent = 'SAVING...';
+      try {
+        await updateUserCharacter(getSession(), chosen.model);
+        setCookie('characterModel', chosen.model, 365);
+        if (chosen.model !== characterModel) {
+          characterModel = chosen.model;
           swapPlayerCharacter(characterModel);
         }
-        openProfileOverlay();
-      });
+        if (statusEl) statusEl.textContent = 'SAVED!';
+        setTimeout(() => {
+          if (statusEl && CHARACTERS[profileCharIndex].model === chosen.model) statusEl.textContent = '';
+        }, 1200);
+      } catch {
+        if (statusEl) statusEl.textContent = 'SAVE FAILED';
+      }
+    }
+
+    document.getElementById('profile-char-left').addEventListener('click', () => {
+      profileCharIndex = (profileCharIndex - 1 + CHARACTERS.length) % CHARACTERS.length;
+      renderProfileCharacterPicker(true);
+    });
+
+    document.getElementById('profile-char-right').addEventListener('click', () => {
+      profileCharIndex = (profileCharIndex + 1) % CHARACTERS.length;
+      renderProfileCharacterPicker(true);
     });
 
     // ── Shop ────────────────────────────────────────────────────────────────────
@@ -437,14 +469,10 @@ async function main() {
       });
     }
 
-    document.getElementById('btn-open-shop').addEventListener('click', () => {
-      document.getElementById('profile-overlay').classList.add('hidden');
-      openShopOverlay();
-    });
+    document.getElementById('btn-open-shop').addEventListener('click', openShopOverlay);
 
     document.getElementById('btn-shop-close').addEventListener('click', () => {
       document.getElementById('shop-overlay').classList.add('hidden');
-      openProfileOverlay();
     });
 
     // ── Advanced Settings ────────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -157,36 +157,37 @@
         <span id="dashboard-online-num">0</span> ONLINE
       </div>
       <div class="dashboard-btn-group">
-        <button class="arcade-btn arcade-btn-green dashboard-big-btn" id="btn-play-online">
-          ▶ PLAY ONLINE
-        </button>
-        <div class="dashboard-btn-desc">JOIN OTHER PLAYERS</div>
-        <button class="arcade-btn arcade-btn-yellow dashboard-big-btn" id="btn-play-bots">
-          ▶ PLAY VS BOTS
-        </button>
-        <div class="dashboard-btn-desc">PRIVATE — NO RANDOMS</div>
-        <button class="arcade-btn arcade-btn-purple dashboard-big-btn" id="btn-adventure-mode">
-          ⚔️ ADVENTURE MODE
-        </button>
-        <div class="dashboard-btn-desc">UNLOCK NEW CHARACTERS</div>
-        <button class="arcade-btn arcade-btn-orange dashboard-big-btn" id="btn-tournament-mode">
-          🏆 TOURNAMENT MODE
-        </button>
-        <div class="dashboard-btn-desc">COMPETE DAILY FOR GLORY</div>
+        <div class="dashboard-mode-grid">
+          <div class="dashboard-mode-card">
+            <button class="arcade-btn arcade-btn-green dashboard-big-btn" id="btn-play-online">
+              ▶ PLAY ONLINE
+            </button>
+            <div class="dashboard-btn-desc">JOIN OTHER PLAYERS</div>
+          </div>
+          <div class="dashboard-mode-card">
+            <button class="arcade-btn arcade-btn-yellow dashboard-big-btn" id="btn-play-bots">
+              ▶ PLAY VS BOTS
+            </button>
+            <div class="dashboard-btn-desc">PRIVATE — NO RANDOMS</div>
+          </div>
+          <div class="dashboard-mode-card">
+            <button class="arcade-btn arcade-btn-purple dashboard-big-btn" id="btn-adventure-mode">
+              ⚔️ ADVENTURE MODE
+            </button>
+            <div class="dashboard-btn-desc">UNLOCK NEW CHARACTERS</div>
+          </div>
+          <div class="dashboard-mode-card">
+            <button class="arcade-btn arcade-btn-orange dashboard-big-btn" id="btn-tournament-mode">
+              🏆 TOURNAMENT MODE
+            </button>
+            <div class="dashboard-btn-desc">COMPETE DAILY FOR GLORY</div>
+          </div>
+        </div>
         <div class="dashboard-secondary-btns">
           <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn" id="btn-stats">📊 MY STATS</button>
           <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn" id="btn-leaderboard-dash">🏆 LEADERBOARD</button>
-          <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn" id="btn-profile">👤 PROFILE</button>
-        </div>
-      </div>
-      <div class="dashboard-audio-section">
-        <div class="dashboard-audio-row">
-          <span class="dashboard-audio-label">🎵 MUSIC</span>
-          <input type="range" id="dash-music-volume" min="0" max="1" step="0.05" class="dashboard-audio-slider" />
-        </div>
-        <div class="dashboard-audio-row">
-          <span class="dashboard-audio-label">🔊 SFX</span>
-          <input type="range" id="dash-sfx-volume" min="0" max="1" step="0.05" class="dashboard-audio-slider" />
+          <button class="arcade-btn arcade-btn-yellow dashboard-secondary-btn" id="btn-open-shop">🛍 SHOP</button>
+          <button class="arcade-btn arcade-btn-dim dashboard-secondary-btn dashboard-icon-btn" id="btn-profile" aria-label="Settings">⚙️</button>
         </div>
       </div>
     </div>
@@ -253,7 +254,7 @@
   <!-- Profile Overlay -->
   <div id="profile-overlay" class="arcade-overlay hidden">
     <div class="arcade-panel profile-panel">
-      <div class="arcade-title" style="font-size: clamp(14px,3vw,20px)">👤 PROFILE</div>
+      <div class="arcade-title" style="font-size: clamp(14px,3vw,20px)">⚙️ SETTINGS</div>
       <div class="profile-section">
         <div class="profile-label">DISPLAY NAME</div>
         <div class="profile-name-row">
@@ -263,12 +264,28 @@
         <div class="arcade-error hidden" id="profile-name-error"></div>
         <div class="profile-name-ok hidden" id="profile-name-ok">✔ NAME UPDATED!</div>
       </div>
-      <div class="profile-section">
-        <div class="profile-label">CHARACTER</div>
-        <button class="arcade-btn arcade-btn-dim profile-char-btn" id="btn-profile-char">CHANGE CHARACTER</button>
+      <div class="profile-section profile-audio-section">
+        <div class="dashboard-audio-row">
+          <span class="dashboard-audio-label">🎵 MUSIC</span>
+          <input type="range" id="dash-music-volume" min="0" max="1" step="0.05" class="dashboard-audio-slider" />
+        </div>
+        <div class="dashboard-audio-row">
+          <span class="dashboard-audio-label">🔊 SFX</span>
+          <input type="range" id="dash-sfx-volume" min="0" max="1" step="0.05" class="dashboard-audio-slider" />
+        </div>
       </div>
-      <div class="profile-section">
-        <button class="arcade-btn arcade-btn-yellow profile-shop-btn" id="btn-open-shop">🛍 SHOP</button>
+      <div class="profile-section profile-character-section">
+        <div class="profile-character-picker" id="profile-character-picker">
+          <button class="char-arrow profile-char-arrow" id="profile-char-left" aria-label="Previous character">◀</button>
+          <div class="char-display profile-char-display">
+            <div class="char-emoji" id="profile-char-emoji"></div>
+            <div class="char-lock-info hidden" id="profile-char-lock-info">
+              <div class="char-lock-icon">🔒</div>
+            </div>
+            <div class="profile-char-save-status" id="profile-char-save-status"></div>
+          </div>
+          <button class="char-arrow profile-char-arrow" id="profile-char-right" aria-label="Next character">▶</button>
+        </div>
       </div>
       <div class="profile-section">
         <button class="arcade-btn arcade-btn-dim" id="btn-adv-settings-open">⚙ ADVANCED SETTINGS</button>

--- a/login.js
+++ b/login.js
@@ -208,8 +208,8 @@ export async function initLogin(onSuccess) {
       const hash = await hashPin(name, pin);
       await saveUser(name, hash, null);
       saveSession(name);
-      // Go to character select — overlay stays until char selected
-      showCharacterSelect(overlay, name, onSuccess);
+      overlay.classList.add('hidden');
+      onSuccess({ username: name, character: '/models/old_man.fbx' });
     } catch (e) {
       setError('signup', 'ERROR — CHECK CONNECTION');
     } finally {

--- a/styles.css
+++ b/styles.css
@@ -2037,3 +2037,93 @@ body {
   font-size: clamp(7px, 1.4vw, 9px) !important;
   padding: 4px 8px !important;
 }
+
+/* Dashboard mode layout: two rows of two primary actions */
+.dashboard-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 14px;
+  width: 100%;
+}
+
+.dashboard-mode-card {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.dashboard-mode-card .dashboard-btn-desc {
+  margin-bottom: 0;
+  text-align: center;
+}
+
+.dashboard-icon-btn {
+  flex: 0 0 auto;
+  min-width: 48px !important;
+  font-size: 16px !important;
+}
+
+.profile-audio-section {
+  gap: 10px;
+}
+
+.profile-audio-section .dashboard-audio-row {
+  width: 100%;
+}
+
+.profile-character-section {
+  padding-top: 8px;
+}
+
+.profile-character-picker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+}
+
+.profile-char-arrow {
+  padding: 10px 12px;
+  font-size: 16px;
+}
+
+.profile-char-display {
+  position: relative;
+  min-height: 110px;
+  max-width: 180px;
+  padding: 12px;
+}
+
+.profile-char-display .char-emoji {
+  font-size: 56px;
+}
+
+.profile-char-display .char-lock-info {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.profile-char-display .char-lock-info.hidden {
+  display: none;
+}
+
+.profile-char-save-status {
+  min-height: 10px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #00ffcc;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+@media (max-width: 560px) {
+  .dashboard-mode-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Rework the dashboard to present primary play modes in a compact 2x2 layout so `PLAY ONLINE` and `PLAY VS BOTS` are on the same row and `ADVENTURE` / `TOURNAMENT` are on the row below. 
- Convert the old “Profile” area into a lightweight `Settings` panel (gear icon) and move audio controls and the character picker into that flow for clearer organization. 
- Replace the modal character chooser with a condensed inline picker that immediately saves the selected character to the user profile and remove the separate character-chooser step after signup.

### Description
- Updated `index.html` to render the dashboard modes inside a new `.dashboard-mode-grid`, replaced the `Profile` button with a gear icon button, and moved the `Shop` button into the dashboard secondary row. 
- Added layout and component styles in `styles.css` for `.dashboard-mode-grid`, `.dashboard-mode-card`, and the compact profile character picker (`.profile-character-picker`, `.profile-char-display`, etc.).
- Modified `app.js` to: initialize and render the inline profile character picker, load unlocked status on open, handle left/right arrow clicks to immediately save the chosen character via `updateUserCharacter`, move audio slider handlers to the Settings overlay, and wire the dashboard `Shop` button to open the shop overlay directly. 
- Changed `login.js` signup flow to skip the separate character-select overlay and default new users to the `old_man` model immediately after signup, and removed the now-unused `showCharacterSelect` import usage from `app.js`.

### Testing
- Ran `npm run build` which completed successfully and produced `dist/` assets (Vite build warnings appeared about large chunks but build succeeded). 
- Attempted to run tests with `npm test -- --runInBand` but the project has no `test` script configured. 
- Tried to run a headless browser for UI screenshots but no browser executable was available in the environment, so visual checks were not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57d77d66b08331a507b70fb65d029e)