### PR TITLE
Corner kicks: nudge ball on-field, use circular taker zone, and add bounds buffers

### DIFF
--- a/app.js
+++ b/app.js
@@ -1974,6 +1974,7 @@ async function main() {
   const SCORE_GOAL_WIDTH = 10;
   const SCORE_GOAL_HEIGHT = 3;
   const SCORE_FIELD_HALF = 50;
+  const BALL_OUT_OF_BOUNDS_BUFFER = 1.0;
 
   const scoreEl = document.createElement('div');
   scoreEl.style.cssText = 'position:fixed;top:16px;left:50%;transform:translateX(-50%);background:rgba(0,0,0,0.6);font-size:28px;font-weight:bold;padding:8px 28px;border-radius:10px;z-index:200;font-family:sans-serif;pointer-events:none;letter-spacing:4px;';
@@ -2118,8 +2119,9 @@ async function main() {
     const pos = soccerBall.getPosition();
     if (!pos) return;
 
-    const outZ = pos.z > SCORE_FIELD_HALF || pos.z < -SCORE_FIELD_HALF;
-    const outX = Math.abs(pos.x) > SCORE_FIELD_X_HALF;
+    const outZ = pos.z > SCORE_FIELD_HALF + BALL_OUT_OF_BOUNDS_BUFFER ||
+                 pos.z < -SCORE_FIELD_HALF - BALL_OUT_OF_BOUNDS_BUFFER;
+    const outX = Math.abs(pos.x) > SCORE_FIELD_X_HALF + BALL_OUT_OF_BOUNDS_BUFFER;
     if (!outX && !outZ) return;
 
     const inX = Math.abs(pos.x) <= SCORE_GOAL_WIDTH / 2;

--- a/setPiece.js
+++ b/setPiece.js
@@ -2,6 +2,31 @@ import * as THREE from 'three';
 
 const FIELD_HALF_X = 30;
 const FIELD_HALF_Z = 50;
+const FIELD_IN_PLAY_BUFFER = 1.0;
+const FIELD_OUT_OF_BOUNDS_BUFFER = 1.0;
+
+function isCircleZone(zone) {
+  return zone?.shape === 'circle';
+}
+
+function isInsideZone(x, z, zone) {
+  if (isCircleZone(zone)) {
+    const dx = x - zone.x;
+    const dz = z - zone.z;
+    return dx * dx + dz * dz <= zone.radius * zone.radius;
+  }
+  return x >= zone.minX && x <= zone.maxX && z >= zone.minZ && z <= zone.maxZ;
+}
+
+function isWellInsideField(x, z) {
+  return Math.abs(x) < FIELD_HALF_X - FIELD_IN_PLAY_BUFFER &&
+         Math.abs(z) < FIELD_HALF_Z - FIELD_IN_PLAY_BUFFER;
+}
+
+function isWellOutOfField(x, z) {
+  return Math.abs(x) > FIELD_HALF_X + FIELD_OUT_OF_BOUNDS_BUFFER ||
+         Math.abs(z) > FIELD_HALF_Z + FIELD_OUT_OF_BOUNDS_BUFFER;
+}
 
 const SET_PIECE_LABELS = {
   throwIn: 'THROW-IN',
@@ -85,11 +110,11 @@ export class SetPieceManager {
       // Check end conditions after lock released
       const bp = soccerBall.getPosition();
       if (bp) {
-        const inField = Math.abs(bp.x) < FIELD_HALF_X && Math.abs(bp.z) < FIELD_HALF_Z;
-        const inZone = bp.x >= a.zone.minX && bp.x <= a.zone.maxX &&
-                       bp.z >= a.zone.minZ && bp.z <= a.zone.maxZ;
+        const inField = isWellInsideField(bp.x, bp.z);
+        const inZone = isInsideZone(bp.x, bp.z, a.zone);
+        const wellOutOfField = isWellOutOfField(bp.x, bp.z);
 
-        if (!inZone && !inField) {
+        if (!inZone && wellOutOfField) {
           soccerBall.body.setTranslation(a.ballFixedPos, true);
           soccerBall.body.setLinvel({ x: 0, y: 0, z: 0 }, true);
           soccerBall.body.setAngvel({ x: 0, y: 0, z: 0 }, true);
@@ -140,6 +165,10 @@ export class SetPieceManager {
   // ─── private ──────────────────────────────────────────────────────────────
 
   _buildZoneVisual(zone) {
+    if (isCircleZone(zone)) {
+      this._buildCircleZoneVisual(zone, 0xffff00, 0.18, 0.02);
+      return;
+    }
     const { minX, maxX, minZ, maxZ } = zone;
     const cx = (minX + maxX) / 2;
     const cz = (minZ + maxZ) / 2;
@@ -173,6 +202,10 @@ export class SetPieceManager {
   }
 
   _buildExclusionZoneVisual(zone) {
+    if (isCircleZone(zone)) {
+      this._buildCircleZoneVisual(zone, 0xff2200, 0.12, 0.015);
+      return;
+    }
     const { minX, maxX, minZ, maxZ } = zone;
     const cx = (minX + maxX) / 2;
     const cz = (minZ + maxZ) / 2;
@@ -201,6 +234,39 @@ export class SetPieceManager {
     const edgesMat = new THREE.LineBasicMaterial({ color: 0xff2200 });
     const edges = new THREE.LineSegments(edgesGeo, edgesMat);
     edges.position.set(cx, y + boxH / 2, cz);
+    this.scene.add(edges);
+    this._zoneMeshes.push(edges);
+  }
+
+
+  _buildCircleZoneVisual(zone, color, opacity, y) {
+    const boxH = 2.5;
+    const floorGeo = new THREE.CircleGeometry(zone.radius, 48);
+    const floorMat = new THREE.MeshBasicMaterial({
+      color,
+      transparent: true,
+      opacity,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const floor = new THREE.Mesh(floorGeo, floorMat);
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.set(zone.x, y, zone.z);
+    this.scene.add(floor);
+    this._zoneMeshes.push(floor);
+
+    const ringGeo = new THREE.RingGeometry(zone.radius - 0.05, zone.radius + 0.05, 64);
+    const ringMat = new THREE.MeshBasicMaterial({ color, side: THREE.DoubleSide });
+    const ring = new THREE.Mesh(ringGeo, ringMat);
+    ring.rotation.x = -Math.PI / 2;
+    ring.position.set(zone.x, y + 0.01, zone.z);
+    this.scene.add(ring);
+    this._zoneMeshes.push(ring);
+
+    const edgesGeo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(zone.radius, zone.radius, boxH, 48, 1, true));
+    const edgesMat = new THREE.LineBasicMaterial({ color });
+    const edges = new THREE.LineSegments(edgesGeo, edgesMat);
+    edges.position.set(zone.x, y + boxH / 2, zone.z);
     this.scene.add(edges);
     this._zoneMeshes.push(edges);
   }
@@ -240,6 +306,10 @@ export class SetPieceManager {
   }
 
   _constrainToZone(body, zone) {
+    if (isCircleZone(zone)) {
+      this._constrainToCircleZone(body, zone);
+      return;
+    }
     const t = body.translation();
     let nx = t.x;
     let nz = t.z;
@@ -259,6 +329,32 @@ export class SetPieceManager {
     }
   }
 
+
+  _constrainToCircleZone(body, zone) {
+    const t = body.translation();
+    const dx = t.x - zone.x;
+    const dz = t.z - zone.z;
+    const dist = Math.sqrt(dx * dx + dz * dz);
+    if (dist <= zone.radius) return;
+
+    const nx = dist > 0.001 ? dx / dist : 1;
+    const nz = dist > 0.001 ? dz / dist : 0;
+    const v = body.linvel();
+    const outwardVel = v.x * nx + v.z * nz;
+    body.setTranslation({
+      x: zone.x + nx * zone.radius,
+      y: t.y,
+      z: zone.z + nz * zone.radius,
+    }, true);
+    if (outwardVel > 0) {
+      body.setLinvel({
+        x: v.x - outwardVel * nx,
+        y: v.y,
+        z: v.z - outwardVel * nz,
+      }, true);
+    }
+  }
+
   // Immediately eject all bodies from their respective zones (call once on set piece creation).
   ejectBodiesNow(otherBodies = [], opposingBodies = []) {
     if (!this.active) return;
@@ -274,6 +370,10 @@ export class SetPieceManager {
   }
 
   _pushOutOfZone(body, zone) {
+    if (isCircleZone(zone)) {
+      this._pushOutOfCircleZone(body, zone);
+      return;
+    }
     const t = body.translation();
     const pad = 0.5;
     const margin = 0.1;
@@ -321,6 +421,42 @@ export class SetPieceManager {
       y: v.y,
       z: chosen.vMask.z === 0 ? 0 : v.z,
     }, true);
+  }
+
+  _pushOutOfCircleZone(body, zone) {
+    const t = body.translation();
+    const pad = 0.5;
+    const margin = 0.1;
+    const radius = zone.radius + pad;
+    const dx = t.x - zone.x;
+    const dz = t.z - zone.z;
+    const dist = Math.sqrt(dx * dx + dz * dz);
+    if (dist > radius) return;
+
+    let nx = dist > 0.001 ? dx / dist : 1;
+    let nz = dist > 0.001 ? dz / dist : 0;
+    let safeX = zone.x + nx * (radius + margin);
+    let safeZ = zone.z + nz * (radius + margin);
+
+    if (Math.abs(safeX) >= FIELD_HALF_X - margin || Math.abs(safeZ) >= FIELD_HALF_Z - margin) {
+      nx = -Math.sign(zone.x || safeX || 1);
+      nz = -Math.sign(zone.z || safeZ || 1);
+      const len = Math.sqrt(nx * nx + nz * nz) || 1;
+      nx /= len;
+      nz /= len;
+      safeX = zone.x + nx * (radius + margin);
+      safeZ = zone.z + nz * (radius + margin);
+    }
+
+    safeX = Math.max(-(FIELD_HALF_X - margin), Math.min(FIELD_HALF_X - margin, safeX));
+    safeZ = Math.max(-(FIELD_HALF_Z - margin), Math.min(FIELD_HALF_Z - margin, safeZ));
+    body.setTranslation({ x: safeX, y: t.y, z: safeZ }, true);
+
+    const v = body.linvel();
+    const outwardVel = v.x * nx + v.z * nz;
+    if (outwardVel < 0) {
+      body.setLinvel({ x: v.x - outwardVel * nx, y: v.y, z: v.z - outwardVel * nz }, true);
+    }
   }
 }
 
@@ -376,15 +512,19 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
       const teamTaking = defendingTeam === 'home' ? 'away' : 'home';
       const cornerX = xSign * FIELD_HALF_X;
       const cornerZ = zSign * FIELD_HALF_Z;
-      const ballFixedPos = { x: cornerX, y: fieldY, z: cornerZ };
+      const cornerInset = 0.8;
+      const ballFixedPos = {
+        x: cornerX - xSign * cornerInset,
+        y: fieldY,
+        z: cornerZ - zSign * cornerInset,
+      };
 
-      // Zone is outside the field; the corner of the zone sits on the field corner
-      const extent = 3.5;
+      // Use a circular corner area that is nudged onto the field instead of a box outside it.
       const zone = {
-        minX: xSign > 0 ? cornerX : cornerX - extent,
-        maxX: xSign > 0 ? cornerX + extent : cornerX,
-        minZ: zSign > 0 ? cornerZ : cornerZ - extent,
-        maxZ: zSign > 0 ? cornerZ + extent : cornerZ,
+        shape: 'circle',
+        x: cornerX - xSign * 1.25,
+        z: cornerZ - zSign * 1.25,
+        radius: 3.0,
       };
       // Opposing team must stay 9 units from the corner (on the field side)
       const exExtent = 9;

--- a/setPiece.js
+++ b/setPiece.js
@@ -240,7 +240,6 @@ export class SetPieceManager {
 
 
   _buildCircleZoneVisual(zone, color, opacity, y) {
-    const boxH = 2.5;
     const floorGeo = new THREE.CircleGeometry(zone.radius, 48);
     const floorMat = new THREE.MeshBasicMaterial({
       color,
@@ -263,12 +262,6 @@ export class SetPieceManager {
     this.scene.add(ring);
     this._zoneMeshes.push(ring);
 
-    const edgesGeo = new THREE.EdgesGeometry(new THREE.CylinderGeometry(zone.radius, zone.radius, boxH, 48, 1, true));
-    const edgesMat = new THREE.LineBasicMaterial({ color });
-    const edges = new THREE.LineSegments(edgesGeo, edgesMat);
-    edges.position.set(zone.x, y + boxH / 2, zone.z);
-    this.scene.add(edges);
-    this._zoneMeshes.push(edges);
   }
 
   _createLabel() {
@@ -522,8 +515,8 @@ export function buildSetPieceParams(ballOutPos, lastTouchedTeam) {
       // Use a circular corner area that is nudged onto the field instead of a box outside it.
       const zone = {
         shape: 'circle',
-        x: cornerX - xSign * 1.25,
-        z: cornerZ - zSign * 1.25,
+        x: cornerX - xSign * 0.5,
+        z: cornerZ - zSign * 0.5,
         radius: 3.0,
       };
       // Opposing team must stay 9 units from the corner (on the field side)


### PR DESCRIPTION
### Motivation
- Prevent corner kick ball/players from being placed exactly on the outer corner and make the taker area feel more natural by moving things slightly onto the field and using a circular zone. 
- Avoid immediate set-piece triggers for tiny edge crossings by adding small in-play/out-of-bounds buffers for the ball. 
- Support circular set-piece zones visually and in physics so corner behavior (ejection, containment) matches the new shape.

### Description
- Replace corner taker box with a circular zone and nudge the corner ball placement slightly inward by adjusting `buildSetPieceParams` (corner handling) in `setPiece.js`. 
- Add circular zone helpers (`isCircleZone`, `isInsideZone`) plus circle-specific rendering (`_buildCircleZoneVisual`), containment (`_constrainToCircleZone`), and ejection (`_pushOutOfCircleZone`) in `setPiece.js`. 
- Add field buffers (`FIELD_IN_PLAY_BUFFER`, `FIELD_OUT_OF_BOUNDS_BUFFER`) and use `isWellInsideField` / `isWellOutOfField` to require the ball to be well inside/outside before changing set-piece state in `setPiece.js`. 
- Add a `BALL_OUT_OF_BOUNDS_BUFFER` to `app.js` and use it when computing out-of-bounds in `checkGoal()` so brief edge crossings are ignored.

### Testing
- Ran `node --check setPiece.js` and it completed without syntax errors. 
- Ran `node --check app.js` and it completed without syntax errors. 
- Built the project with `npm run build` and the production build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e1b7bde08333a6e8975ca30026ce)