### PR TITLE
Add purchasable locked characters and set character costs

### DIFF
--- a/app.js
+++ b/app.js
@@ -283,7 +283,12 @@ async function main() {
       renderProfileCharacterPicker(false);
       profileOverlay.classList.remove('hidden');
       try {
-        profileUnlockedKeys = await getUserUpgrades(getSession()) || {};
+        const [upgrades, stats] = await Promise.all([
+          getUserUpgrades(getSession()),
+          getPlayerStats(currentPlayerName),
+        ]);
+        profileUnlockedKeys = upgrades || {};
+        profileCoins = stats?.coins || 0;
         renderProfileCharacterPicker(false);
       } catch { /* keep current unlock display */ }
     }
@@ -344,6 +349,7 @@ async function main() {
 
     let profileCharIndex = Math.max(0, CHARACTERS.findIndex(c => c.model === characterModel));
     let profileUnlockedKeys = {};
+    let profileCoins = 0;
 
     function profileCharacterUnlocked(character) {
       return character.free || !!profileUnlockedKeys[`char_${character.key}`];
@@ -352,9 +358,15 @@ async function main() {
     async function renderProfileCharacterPicker(saveChoice = false) {
       const chosen = CHARACTERS[profileCharIndex];
       const statusEl = document.getElementById('profile-char-save-status');
+      const buyBtn = document.getElementById('profile-char-buy');
       document.getElementById('profile-char-emoji').textContent = chosen.emoji;
       const locked = !profileCharacterUnlocked(chosen);
       document.getElementById('profile-char-lock-info').classList.toggle('hidden', !locked);
+      if (buyBtn) {
+        buyBtn.classList.toggle('hidden', !locked);
+        buyBtn.textContent = `🪙 ${chosen.cost || 0} — UNLOCK`;
+        buyBtn.disabled = false;
+      }
       if (statusEl) statusEl.textContent = locked ? 'LOCKED' : '';
       if (locked || !saveChoice) return;
 
@@ -383,6 +395,38 @@ async function main() {
     document.getElementById('profile-char-right').addEventListener('click', () => {
       profileCharIndex = (profileCharIndex + 1) % CHARACTERS.length;
       renderProfileCharacterPicker(true);
+    });
+
+    document.getElementById('profile-char-buy').addEventListener('click', async () => {
+      const chosen = CHARACTERS[profileCharIndex];
+      const btn = document.getElementById('profile-char-buy');
+      const statusEl = document.getElementById('profile-char-save-status');
+      const cost = chosen.cost || 0;
+      if (!btn || profileCharacterUnlocked(chosen)) return;
+      if (profileCoins < cost) {
+        btn.textContent = 'NOT ENOUGH 🪙';
+        btn.disabled = true;
+        setTimeout(() => {
+          btn.textContent = `🪙 ${cost} — UNLOCK`;
+          btn.disabled = false;
+        }, 2000);
+        return;
+      }
+      btn.textContent = 'BUYING...';
+      btn.disabled = true;
+      try {
+        await purchaseUpgrade(currentPlayerName, `char_${chosen.key}`, cost);
+        profileUnlockedKeys[`char_${chosen.key}`] = true;
+        profileCoins -= cost;
+        if (statusEl) statusEl.textContent = 'UNLOCKED!';
+        renderProfileCharacterPicker(true);
+      } catch (err) {
+        btn.textContent = err.message === 'NOT_ENOUGH_COINS' ? 'NOT ENOUGH 🪙' : 'ERROR!';
+        setTimeout(() => {
+          btn.textContent = `🪙 ${cost} — UNLOCK`;
+          btn.disabled = false;
+        }, 2000);
+      }
     });
 
     // ── Shop ────────────────────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -284,6 +284,7 @@
             </div>
             <div class="profile-char-save-status" id="profile-char-save-status"></div>
           </div>
+          <button class="arcade-btn arcade-btn-yellow profile-char-buy hidden" id="profile-char-buy">🪙 0 — UNLOCK</button>
           <button class="char-arrow profile-char-arrow" id="profile-char-right" aria-label="Next character">▶</button>
         </div>
       </div>

--- a/login.js
+++ b/login.js
@@ -236,13 +236,13 @@ export async function initLogin(onSuccess) {
 
 // Characters available to unlock via Adventure Mode (in round order)
 export const ADVENTURE_ORDER = [
-  { label: 'COWBOY',      model: '/models/cowboy.fbx',        emoji: '🤠', key: 'cowboy' },
-  { label: 'GOLEM',       model: '/models/golem.fbx',         emoji: '🪨', key: 'golem' },
-  { label: 'ZOMBIE',      model: '/models/zombie.fbx',        emoji: '🧟', key: 'zombie' },
-  { label: 'ZOMBIE BOY',  model: '/models/zombie_boy.fbx',    emoji: '🧟', key: 'zombie_boy' },
-  { label: 'ZOMBIE GRN',  model: '/models/zombie_green.fbx',  emoji: '🟢', key: 'zombie_green' },
-  { label: 'CHIMP',       model: '/models/Chimpanzee.fbx',    emoji: '🐒', key: 'chimpanzee' },
-  { label: 'SEAGULL',     model: '/models/seagull.fbx',       emoji: '🐦', key: 'seagull' },
+  { label: 'COWBOY',      model: '/models/cowboy.fbx',        emoji: '🤠', key: 'cowboy', cost: 75 },
+  { label: 'GOLEM',       model: '/models/golem.fbx',         emoji: '🪨', key: 'golem', cost: 100 },
+  { label: 'ZOMBIE',      model: '/models/zombie.fbx',        emoji: '🧟', key: 'zombie', cost: 150 },
+  { label: 'ZOMBIE BOY',  model: '/models/zombie_boy.fbx',    emoji: '🧟', key: 'zombie_boy', cost: 250 },
+  { label: 'ZOMBIE GRN',  model: '/models/zombie_green.fbx',  emoji: '🟢', key: 'zombie_green', cost: 200 },
+  { label: 'CHIMP',       model: '/models/Chimpanzee.fbx',    emoji: '🐒', key: 'chimpanzee', cost: 500 },
+  { label: 'SEAGULL',     model: '/models/seagull.fbx',       emoji: '🐦', key: 'seagull', cost: 350 },
 ];
 
 const CHARACTERS = [
@@ -291,7 +291,7 @@ async function showCharacterSelect(overlay, username, onSuccess) {
         <button class="char-arrow" id="char-right">▶</button>
       </div>
       <button class="arcade-btn arcade-btn-green" id="char-ok">OK!</button>
-      <button class="arcade-btn arcade-btn-yellow hidden" id="char-buy">🪙 100 — UNLOCK</button>
+      <button class="arcade-btn arcade-btn-yellow hidden" id="char-buy">🪙 0 — UNLOCK</button>
       <div class="char-buy-note hidden" id="char-buy-note">OR BEAT THEM IN ADVENTURE MODE</div>
     </div>
   `;
@@ -313,7 +313,7 @@ async function showCharacterSelect(overlay, username, onSuccess) {
     el('char-buy').classList.toggle('hidden', !locked);
     el('char-buy-note').classList.toggle('hidden', !locked);
     if (locked) {
-      el('char-buy').textContent = `🪙 100 — UNLOCK`;
+      el('char-buy').textContent = `🪙 ${c.cost || 0} — UNLOCK`;
       el('char-buy').disabled = false;
     }
   }
@@ -342,17 +342,18 @@ async function showCharacterSelect(overlay, username, onSuccess) {
   el('char-buy').addEventListener('click', async () => {
     const chosen = CHARACTERS[idx];
     const btn = el('char-buy');
-    if (playerCoins < 100) {
+    const cost = chosen.cost || 0;
+    if (playerCoins < cost) {
       btn.textContent = 'NOT ENOUGH 🪙';
-      setTimeout(() => { btn.textContent = '🪙 100 — UNLOCK'; btn.disabled = false; }, 2000);
+      setTimeout(() => { btn.textContent = `🪙 ${cost} — UNLOCK`; btn.disabled = false; }, 2000);
       return;
     }
     btn.textContent = 'BUYING...';
     btn.disabled = true;
     try {
-      await purchaseUpgrade(username, `char_${chosen.key}`, 100);
+      await purchaseUpgrade(username, `char_${chosen.key}`, cost);
       unlockedKeys[`char_${chosen.key}`] = true;
-      playerCoins -= 100;
+      playerCoins -= cost;
       render();
     } catch (err) {
       if (err.message === 'NOT_ENOUGH_COINS') {
@@ -360,7 +361,7 @@ async function showCharacterSelect(overlay, username, onSuccess) {
       } else {
         btn.textContent = 'ERROR!';
       }
-      setTimeout(() => { btn.textContent = '🪙 100 — UNLOCK'; btn.disabled = false; }, 2000);
+      setTimeout(() => { btn.textContent = `🪙 ${cost} — UNLOCK`; btn.disabled = false; }, 2000);
     }
   });
 }


### PR DESCRIPTION
### Motivation
- Make locked characters purchasable from both the character-select overlay and the profile/settings picker and set custom coin costs per character.

### Description
- Added a `cost` field to each character in `ADVENTURE_ORDER` and configured costs: Cowboy 75, Golem 100, Zombie 150, Zombie Green 200, Zombie Boy 250, Seagull 350, Chimpanzee 500 (`login.js`).
- Updated the character-select overlay to display each character's cost and charge that cost when purchasing instead of a fixed 100 coins (`login.js`).
- Added a buy button to the profile/settings character picker markup (`index.html`) and wired it in `app.js` to show cost, check the player's coin balance, call `purchaseUpgrade`, update local unlock state, and reflect the new selection.
- Loaded profile coin balance via `getPlayerStats` when opening the profile overlay so the profile buy button can validate funds and deduct the cost (`app.js`).

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57f2366a548333b7bb32d289f152df)