### PR TITLE
Add mobile responsive styles for in-game settings panel

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1066,6 +1066,44 @@ body {
   .arcade-btn { padding: 10px 14px; min-width: 100px; }
   .char-emoji { font-size: 48px; }
   .char-arrow { padding: 10px 12px; font-size: 16px; }
+
+  /* In-game settings panel */
+  #settings-panel {
+    flex-direction: column;
+    min-width: 0;
+    width: calc(100vw - 24px);
+    max-width: calc(100vw - 24px);
+    min-height: 0;
+    max-height: calc(100vh - 24px);
+    border-radius: 8px;
+  }
+
+  #settings-side-tabs {
+    flex-direction: row;
+    min-width: 0;
+    padding: 0;
+    gap: 0;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+  }
+
+  .side-tab-btn {
+    flex: 1;
+    text-align: center;
+    padding: 10px 4px;
+    font-size: 11px;
+    border-left: none;
+    border-bottom: 3px solid transparent;
+  }
+
+  .side-tab-btn.active {
+    border-left-color: transparent;
+    border-bottom-color: #3399ff;
+  }
+
+  #settings-tab-body {
+    padding: 14px;
+    max-height: calc(100vh - 120px);
+  }
 }
 
 /* ════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Added mobile-responsive CSS styles for the in-game settings panel to improve usability on smaller screens.

## Key Changes
- **Settings panel layout**: Configured flex-direction to column with responsive width/height constraints (100vw/100vh minus padding)
- **Tab navigation**: Changed side tabs to horizontal row layout with bottom border indicator instead of left border
- **Tab styling**: Updated active tab indicator to use bottom border color (#3399ff) for mobile-friendly tab selection
- **Content area**: Added padding and max-height constraints to settings tab body for proper scrolling on mobile devices

## Implementation Details
- All dimensions use viewport-relative calculations (calc expressions) to ensure proper scaling on mobile
- Tab buttons now flex equally across the width with centered text alignment
- Active tab state uses bottom border instead of left border for better mobile UX
- Settings panel respects safe margins (24px) from viewport edges

https://claude.ai/code/session_018cyRzDMoeUKaDr4giV5i7y