### PR TITLE
Add corner kick positioning for non-taker AI players

### DIFF
--- a/aiPlayer.js
+++ b/aiPlayer.js
@@ -78,6 +78,20 @@ export class AIPlayer {
     return ballPos.clone().add(backingOffset);
   }
 
+  _getCornerKickPosition(formationIndex, formationCount, goalZ) {
+    // Spread non-taker bots around the goal mouth during a corner kick.
+    const count = Math.max(1, formationCount);
+    const index = Math.max(0, Math.min(count - 1, formationIndex));
+    // Positions spread along X from -10 to +10, at varying depths in front of goal
+    const xSlots = [-9, -5, -1, 3, 7, 11];
+    const zDepths = [5, 7, 9, 6, 8, 10]; // distance in front of goal line
+    const slot = index % xSlots.length;
+    const x = xSlots[slot];
+    const zSign = goalZ < 0 ? -1 : 1;
+    const z = goalZ - zSign * zDepths[slot];
+    return new THREE.Vector3(x, 0, z);
+  }
+
   _getFormationPosition(ballPos, formationIndex, formationCount, chaserIndex, chaserPosition) {
     const count = Math.max(1, formationCount);
     const index = Math.max(0, Math.min(count - 1, formationIndex));
@@ -133,7 +147,7 @@ export class AIPlayer {
     }
   }
 
-  update(delta, soccerBall, { pursueBall = true, formationIndex = 0, formationCount = 1, chaserIndex = null, chaserPosition = null, teammates = [], opponents = [], humanTeammates = [] } = {}) {
+  update(delta, soccerBall, { pursueBall = true, formationIndex = 0, formationCount = 1, chaserIndex = null, chaserPosition = null, teammates = [], opponents = [], humanTeammates = [], cornerKickGoalZ = null } = {}) {
     if (!this.body) return;
 
     const mixer = this.model.userData.mixer;
@@ -317,9 +331,14 @@ export class AIPlayer {
 
       targetPos = ballPos.clone().sub(clampedDir.clone().multiplyScalar(0.4));
     } else {
-      targetPos = pursueBall
-        ? this._getBallPressurePosition(ballPos)
-        : this._getFormationPosition(ballPos, formationIndex, formationCount, chaserIndex, chaserPosition);
+      if (!pursueBall && cornerKickGoalZ !== null) {
+        targetPos = this._getCornerKickPosition(formationIndex, formationCount, cornerKickGoalZ);
+        targetPos.y = ballPos.y;
+      } else {
+        targetPos = pursueBall
+          ? this._getBallPressurePosition(ballPos)
+          : this._getFormationPosition(ballPos, formationIndex, formationCount, chaserIndex, chaserPosition);
+      }
     }
 
     const moveDir = new THREE.Vector3(targetPos.x - t.x, 0, targetPos.z - t.z);

--- a/app.js
+++ b/app.js
@@ -3459,6 +3459,14 @@ async function main() {
             humanTeammates.push(new THREE.Vector3(lt.x, lt.y, lt.z));
           }
 
+          // During a corner kick, non-taker bots position near the attacking goal.
+          let cornerKickGoalZ = null;
+          if (sp?.type === 'cornerKick' && sp.teamTaking === team && ai !== ballChaser) {
+            // The goal being attacked is opposite to the corner's z side.
+            // ballFixedPos.z tells us which end the corner is at; bots attack the same end.
+            cornerKickGoalZ = sp.ballFixedPos.z > 0 ? 50 : -50;
+          }
+
           ai.update(frameDelta, soccerBall, {
             pursueBall: !ballChaser || ai === ballChaser,
             formationIndex: index,
@@ -3467,7 +3475,8 @@ async function main() {
             chaserPosition: ballChaserPosition,
             teammates: players,
             opponents,
-            humanTeammates
+            humanTeammates,
+            cornerKickGoalZ
           });
         } else {
           ai.model.userData.mixer?.update(frameDelta);


### PR DESCRIPTION
## Summary
This PR adds specialized positioning logic for AI players during corner kicks. Non-taker players now position themselves strategically around the attacking goal instead of using standard formation positioning.

## Key Changes
- **New method `_getCornerKickPosition()`**: Spreads non-taker bots around the goal mouth during corner kicks with positions along the X-axis (-9 to +11) and varying depths in front of the goal (5-10 units)
- **Updated `update()` method signature**: Added `cornerKickGoalZ` parameter to the options object to pass corner kick goal information to AI players
- **Corner kick positioning logic**: When a corner kick is active and the AI player is not the ball chaser, the player uses the new corner kick positioning instead of standard formation positioning
- **Goal detection in app.js**: Determines which goal is being attacked during a corner kick based on the ball's fixed position and passes this information to each non-taker AI player

## Implementation Details
- Corner kick positions are calculated relative to the attacking goal (goalZ of either 50 or -50)
- The X-axis spread uses 6 predefined slots to distribute players across the goal mouth width
- Z-depth varies per slot to create a more natural clustering around the goal area
- The positioning respects the ball's Y position to maintain proper vertical alignment
- Only applies when `pursueBall` is false and `cornerKickGoalZ` is provided

https://claude.ai/code/session_013yce1ubrrqJirbMo2zg5Lo