### PR TITLE
Replace solid sky color with cubemap skybox texture

### DIFF
--- a/app.js
+++ b/app.js
@@ -1711,7 +1711,10 @@ async function main() {
   };
 
   const scene = new THREE.Scene();
-  scene.background = new THREE.Color(0x87CEEB);
+  const cubeLoader = new THREE.CubeTextureLoader();
+  cubeLoader.setPath('/assets/skybox/');
+  const skyboxTexture = cubeLoader.load(['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png']);
+  scene.background = skyboxTexture;
 
   // ── Rainbow trail system ───────────────────────────────────────────────────
   const TRAIL_COLORS = [0xff0000, 0xff7700, 0xffee00, 0x00ee00, 0x0088ff, 0x8800ff];


### PR DESCRIPTION
## Summary
Replaced the static solid blue background with a dynamic cubemap skybox texture loaded from image files, enhancing the visual quality of the 3D scene.

## Key Changes
- Removed hardcoded solid sky blue color (`0x87CEEB`) from scene background
- Implemented `THREE.CubeTextureLoader` to load cubemap textures from six image files (px.png, nx.png, py.png, ny.png, pz.png, nz.png)
- Set asset path to `/assets/skybox/` for texture loading
- Applied loaded cubemap texture as the scene background

## Implementation Details
The cubemap is loaded using Three.js's `CubeTextureLoader` with the standard six-face cubemap format (positive/negative X, Y, Z axes). This provides a more immersive and realistic environment compared to the previous flat color background.

https://claude.ai/code/session_016HK7CC7gkJTT6ERzcyZB85