### PR TITLE
Adjust mountain ring scale and snow cap positioning

### DIFF
--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -633,14 +633,14 @@ function buildMountainMesh(rng, baseWidth, baseDepth, peakHeight, segments) {
 export function createMountainRing(scene) {
   const rng = getSeededRandom('mountainRing');
 
-  const RING_RADIUS = 175;      // distance from world centre
+  const RING_RADIUS = 140;      // distance from world centre
   const MOUNTAIN_COUNT = 28;    // number of peaks in the ring
-  const BASE_W_MIN = 30;
-  const BASE_W_MAX = 60;
-  const BASE_D_MIN = 20;
-  const BASE_D_MAX = 40;
-  const HEIGHT_MIN = 35;
-  const HEIGHT_MAX = 80;
+  const BASE_W_MIN = 22;
+  const BASE_W_MAX = 42;
+  const BASE_D_MIN = 15;
+  const BASE_D_MAX = 28;
+  const HEIGHT_MIN = 24;
+  const HEIGHT_MAX = 55;
   const SEGMENTS = 7;           // low segment count = faceted low-poly look
 
   // Snow-capped stone palette
@@ -679,7 +679,7 @@ export function createMountainRing(scene) {
       flatShading: true,
     });
     const meshSnow = new THREE.Mesh(geoSnow, matSnow);
-    meshSnow.position.set(cx, ph - snowBase * 0.05, cz);
+    meshSnow.position.set(cx, ph - snowBase, cz);
     meshSnow.rotation.y = meshRock.rotation.y + (rng() - 0.5) * 0.4;
     meshSnow.castShadow = true;
     scene.add(meshSnow);


### PR DESCRIPTION
## Summary
This PR refines the mountain ring generation by reducing the overall scale of mountains and correcting the snow cap positioning to better match the peak heights.

## Key Changes
- **Ring radius**: Reduced from 175 to 140 units to bring mountains closer to world center
- **Mountain dimensions**: Scaled down all base width, depth, and height parameters by approximately 30%
  - Base width: 30-60 → 22-42
  - Base depth: 20-40 → 15-28
  - Peak height: 35-80 → 24-55
- **Snow cap positioning**: Fixed calculation from `ph - snowBase * 0.05` to `ph - snowBase` to properly position snow caps relative to peak height

## Implementation Details
The snow cap positioning fix removes the 0.05 multiplier that was causing snow caps to sit too high on the peaks. The new calculation directly subtracts the snow base height from the peak height, ensuring proper visual alignment. These changes work together to create a more proportionate and visually cohesive mountain ring.

https://claude.ai/code/session_018WacAMBM9EiMqARdQ2t79F