### PR TITLE
Add brightness control and animation switching for models

### DIFF
--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -165,7 +165,7 @@ export function createPlayerModel(
 
                   const basicParams = {
                     map: mat.map || null,
-                    color: (mat.color && mat.color.clone()) || new THREE.Color(0xffffff),
+                    color: (mat.color && mat.color.clone().multiplyScalar(brightness)) || new THREE.Color(brightness, brightness, brightness),
                     transparent: !!mat.transparent,
                     opacity: (typeof mat.opacity === 'number') ? mat.opacity : 1,
                     side: mat.side ?? THREE.FrontSide,
@@ -219,6 +219,8 @@ export function createPlayerModel(
             });
           }
 
+
+          const brightness = config.brightness ?? 1.0;
 
           // Scale and center the model so it rotates around its midpoint
           const scale = config.scale ?? 1;

--- a/public/models/Chimpanzee.json
+++ b/public/models/Chimpanzee.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.00012,
-  "yOffset": -0.9
+  "yOffset": -0.9,
+  "brightness": 1.0
 }

--- a/public/models/base_character_2.json
+++ b/public/models/base_character_2.json
@@ -1,5 +1,6 @@
 {
   "scale": 0.012,
   "yOffset": 0.15,
-  "zOffset": 0.0
+  "zOffset": 0.0,
+  "brightness": 1.0
 }

--- a/public/models/cowboy.json
+++ b/public/models/cowboy.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.4,
-  "yOffset": -1.0
+  "yOffset": -1.0,
+  "brightness": 1.0
 }

--- a/public/models/fans/the_green_wizard_gnome_n64_style.json
+++ b/public/models/fans/the_green_wizard_gnome_n64_style.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.02,
+  "brightness": 1.0,
   "animations": ["Wizard_Gnome_Armature|idle","Wizard_Gnome_Armature|Curse","Wizard_Gnome_Armature|disagree","Wizard_Gnome_Armature|Fall","Wizard_Gnome_Armature|Walking"]
 }

--- a/public/models/golem.json
+++ b/public/models/golem.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.004,
-  "yOffset": -1.05
+  "yOffset": -1.05,
+  "brightness": 1.0
 }

--- a/public/models/old_man.json
+++ b/public/models/old_man.json
@@ -1,5 +1,6 @@
 {
   "scale": 0.01,
   "yOffset": -1.0,
-  "zOffset": 0.0
+  "zOffset": 0.0,
+  "brightness": 1.0
 }

--- a/public/models/seagull.json
+++ b/public/models/seagull.json
@@ -1,5 +1,6 @@
 {
   "scale": 0.00008,
   "yOffset": -0.85,
-  "zOffset": 0.0
+  "zOffset": 0.0,
+  "brightness": 1.0
 }

--- a/public/models/zombie.json
+++ b/public/models/zombie.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.007,
-  "yOffset": -1.0
+  "yOffset": -1.0,
+  "brightness": 1.0
 }

--- a/public/models/zombie_boy.json
+++ b/public/models/zombie_boy.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.01,
-  "yOffset": -0.95
+  "yOffset": -0.95,
+  "brightness": 1.0
 }

--- a/public/models/zombie_green.json
+++ b/public/models/zombie_green.json
@@ -1,4 +1,5 @@
 {
   "scale": 0.0001,
-  "yOffset": 0.05
+  "yOffset": 0.05,
+  "brightness": 1.0
 }

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -547,6 +547,13 @@ export async function addFans(scene) {
   ];
 
   const mixers = [];
+
+  let config = {};
+  try {
+    const res = await fetch('/models/fans/the_green_wizard_gnome_n64_style.json');
+    if (res.ok) config = await res.json();
+  } catch (e) {}
+
   let gltf;
   try {
     gltf = await loadGLTF('/models/fans/the_green_wizard_gnome_n64_style.glb');
@@ -555,23 +562,54 @@ export async function addFans(scene) {
     return mixers;
   }
 
-  const fanScale = 0.02;
-  const animName = 'Wizard_Gnome_Armature|idle';
+  const fanScale = config.scale ?? 0.02;
+  const animNames = Array.isArray(config.animations)
+    ? config.animations
+    : [config.animations ?? 'Wizard_Gnome_Armature|idle'];
+  const brightness = config.brightness ?? 1.0;
 
   for (const pos of fanPositions) {
     const model = cloneSkinnedModel(gltf.scene);
     model.position.set(pos.x, 0, pos.z);
     model.scale.setScalar(fanScale);
-    // model.rotation.y = 
     model.rotation.x = Math.PI / 2;
     model.rotation.z = -Math.atan2(-pos.x, -pos.z);
-    model.traverse(child => { if (child.isMesh) child.castShadow = true; });
+    model.traverse(child => {
+      if (child.isMesh) {
+        child.castShadow = true;
+        if (brightness !== 1.0) {
+          const mats = Array.isArray(child.material) ? child.material : [child.material];
+          mats.forEach(m => { if (m && m.color) m.color.multiplyScalar(brightness); });
+        }
+      }
+    });
     scene.add(model);
 
     if (gltf.animations && gltf.animations.length > 0) {
       const mixer = new THREE.AnimationMixer(model);
-      const clip = THREE.AnimationClip.findByName(gltf.animations, animName) ?? gltf.animations[0];
-      mixer.clipAction(clip).play();
+      let currentAction = null;
+
+      const playAnim = (name) => {
+        const clip = THREE.AnimationClip.findByName(gltf.animations, name) ?? gltf.animations[0];
+        const next = mixer.clipAction(clip);
+        if (currentAction && currentAction !== next) {
+          currentAction.fadeOut(0.5);
+          next.reset().fadeIn(0.5).play();
+        } else {
+          next.play();
+        }
+        currentAction = next;
+      };
+
+      const pickRandom = () => animNames[Math.floor(Math.random() * animNames.length)];
+      playAnim(pickRandom());
+
+      const scheduleSwitch = () => {
+        const delay = 8000 + Math.random() * 7000;
+        setTimeout(() => { playAnim(pickRandom()); scheduleSwitch(); }, delay);
+      };
+      scheduleSwitch();
+
       mixers.push(mixer);
     }
   }


### PR DESCRIPTION
## Summary
This PR adds brightness control and dynamic animation switching capabilities to 3D models throughout the application. Models can now be configured with a brightness multiplier, and the gnome fan model supports cycling through multiple animations.

## Key Changes
- **Brightness Control**: Added `brightness` configuration parameter to all model JSON files (defaulting to 1.0) and implemented brightness scaling in both `worldGeneration.js` and `playerModel.js`
- **Dynamic Animation Switching**: Implemented animation cycling for the gnome fan model that randomly switches between configured animations every 8-15 seconds with smooth fade transitions
- **Configuration Loading**: Added JSON configuration file loading for the gnome fan model to support flexible animation and brightness settings
- **Animation Blending**: Implemented smooth crossfading between animations using `fadeOut(0.5)` and `fadeIn(0.5)` transitions

## Implementation Details
- The brightness parameter is applied by multiplying material colors with the brightness scalar value
- Animation switching uses a recursive `scheduleSwitch()` function with randomized delays (8000-15000ms) to create natural variation
- The `playAnim()` helper function manages animation state and ensures proper cleanup of previous animations before starting new ones
- All existing model configuration files were updated to include the new `brightness` field for consistency
- The gnome fan model now supports an array of animation names that can be cycled through, with fallback to the first available animation if a named animation isn't found

https://claude.ai/code/session_01A8s4XWAFDgjtuih4DVmQo1