### PR TITLE
Add lampposts with point lights around the field perimeter

### DIFF
--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -490,6 +490,20 @@ export async function addSceneryProps(scene) {
     { url: '/assets/props/medieval_building_005.glb',   x:  55, z:  72, s: building5_scale,   r: -0.8 },
   ];
 
+  // Lamppost positions along the long sides and ends of the field
+  const lamppostScale = 5;
+  const lampLightHeight = 9; // approximate height of the lamp head at scale 5
+  const lampposts = [
+    // Left sideline (x negative)
+    { x: -36, z: -38 }, { x: -36, z: -19 }, { x: -36, z:  0 }, { x: -36, z:  19 }, { x: -36, z:  38 },
+    // Right sideline (x positive)
+    { x:  36, z: -38 }, { x:  36, z: -19 }, { x:  36, z:  0 }, { x:  36, z:  19 }, { x:  36, z:  38 },
+    // North end (z negative)
+    { x: -15, z: -56 }, { x:  15, z: -56 },
+    // South end (z positive)
+    { x: -15, z:  56 }, { x:  15, z:  56 },
+  ];
+
   const cache = new Map();
   for (const p of placements) {
     if (!cache.has(p.url)) {
@@ -509,6 +523,31 @@ export async function addSceneryProps(scene) {
       if (child.isMesh) { child.castShadow = true; child.receiveShadow = true; }
     });
     scene.add(clone);
+  }
+
+  // Load and place lampposts, one PointLight per post
+  let lampGltf;
+  try {
+    lampGltf = await loadGLTF('/assets/props/low-poly_lamppost.glb');
+  } catch (e) {
+    console.warn('addSceneryProps: failed to load lamppost', e);
+    lampGltf = null;
+  }
+
+  for (const lp of lampposts) {
+    if (lampGltf) {
+      const clone = lampGltf.scene.clone(true);
+      clone.position.set(lp.x, 0, lp.z);
+      clone.scale.setScalar(lamppostScale);
+      clone.traverse(child => {
+        if (child.isMesh) { child.castShadow = true; child.receiveShadow = true; }
+      });
+      scene.add(clone);
+    }
+
+    const light = new THREE.PointLight(0xffd580, 2.5, 45, 2);
+    light.position.set(lp.x, lampLightHeight, lp.z);
+    scene.add(light);
   }
 }
 


### PR DESCRIPTION
## Summary
This change adds decorative lampposts with dynamic lighting around the perimeter of the game field, improving the visual atmosphere of the scene.

## Key Changes
- Added 14 lamppost positions strategically placed along the field's sidelines and end zones
  - 5 lampposts on each long sideline (left and right)
  - 2 lampposts on each end (north and south)
- Implemented lamppost model loading from `/assets/props/low-poly_lamppost.glb`
- Added a `PointLight` for each lamppost with warm color (0xffd580) and appropriate intensity/range for ambient field lighting
- Configured lampposts with proper shadow casting and receiving for visual consistency with other scene props
- Included error handling for lamppost model loading with graceful fallback (lights still render if model fails to load)

## Implementation Details
- Lampposts are scaled uniformly at 5x scale with light sources positioned at height 9 to approximate the lamp head position
- Each light has intensity 2.5 and range 45 units, creating overlapping warm ambient lighting across the field
- Lampposts follow the same shadow setup pattern as other scenery props (castShadow and receiveShadow enabled)
- The lighting setup complements the existing medieval building scenery

https://claude.ai/code/session_017zmE2s8JvheJtme7FwTiES