### PR TITLE
Replace goal net with white mesh grid visualization

### DIFF
--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -177,10 +177,26 @@ function addGoal(scene, zSign, rapierWorld, color = 0xffffff) {
 
   // Back net
   buildNetGrid(GOAL_WIDTH, GOAL_HEIGHT, 0, 0, zSign * GOAL_DEPTH);
-  // Left side net
-  buildNetGrid(GOAL_DEPTH, GOAL_HEIGHT, -GOAL_WIDTH / 2, 0, 0, zSign > 0 ? -Math.PI / 2 : Math.PI / 2);
-  // Right side net
-  buildNetGrid(GOAL_DEPTH, GOAL_HEIGHT, GOAL_WIDTH / 2, 0, 0, zSign > 0 ? Math.PI / 2 : -Math.PI / 2);
+
+  // Side nets — built directly in ZY plane so no rotation is needed
+  for (const xPost of [-GOAL_WIDTH / 2, GOAL_WIDTH / 2]) {
+    const cols = Math.round(GOAL_DEPTH / cellSize);
+    const rows = Math.round(GOAL_HEIGHT / cellSize);
+    const positions = [];
+    // Horizontal lines (along Z)
+    for (let r = 0; r <= rows; r++) {
+      const y = (r / rows) * GOAL_HEIGHT;
+      positions.push(xPost, y, 0, xPost, y, zSign * GOAL_DEPTH);
+    }
+    // Vertical lines (along Y)
+    for (let c = 0; c <= cols; c++) {
+      const z = (c / cols) * zSign * GOAL_DEPTH;
+      positions.push(xPost, 0, z, xPost, GOAL_HEIGHT, z);
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    netGroup.add(new THREE.LineSegments(geo, lineMat));
+  }
   // Top net
   {
     const cols = Math.round(GOAL_WIDTH / cellSize);

--- a/worldGeneration.js
+++ b/worldGeneration.js
@@ -144,15 +144,60 @@ function addGoal(scene, zSign, rapierWorld, color = 0xffffff) {
     );
   }
 
-  // Net (back plane)
-  const netMat = new THREE.MeshStandardMaterial({ color, transparent: true, opacity: 0.25, side: THREE.DoubleSide });
-  const net = new THREE.Mesh(
-    new THREE.PlaneGeometry(GOAL_WIDTH, GOAL_HEIGHT),
-    netMat
-  );
-  net.position.set(0, GOAL_HEIGHT / 2, zPos + zSign * GOAL_DEPTH);
-  net.rotation.y = zSign > 0 ? 0 : Math.PI;
-  scene.add(net);
+  // Net — white mesh grid (back plane + side planes + top plane)
+  const netGroup = new THREE.Group();
+  netGroup.position.set(0, 0, zPos);
+  scene.add(netGroup);
+
+  const lineMat = new THREE.LineBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.7 });
+  const cellSize = 0.4;
+
+  function buildNetGrid(width, height, offsetX, offsetY, offsetZ, rotY = 0) {
+    const cols = Math.round(width / cellSize);
+    const rows = Math.round(height / cellSize);
+    const positions = [];
+
+    // Horizontal lines
+    for (let r = 0; r <= rows; r++) {
+      const y = (r / rows) * height + offsetY;
+      positions.push(-width / 2 + offsetX, y, offsetZ, width / 2 + offsetX, y, offsetZ);
+    }
+    // Vertical lines
+    for (let c = 0; c <= cols; c++) {
+      const x = (c / cols) * width - width / 2 + offsetX;
+      positions.push(x, offsetY, offsetZ, x, offsetY + height, offsetZ);
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    const lines = new THREE.LineSegments(geo, lineMat);
+    if (rotY) lines.rotation.y = rotY;
+    netGroup.add(lines);
+  }
+
+  // Back net
+  buildNetGrid(GOAL_WIDTH, GOAL_HEIGHT, 0, 0, zSign * GOAL_DEPTH);
+  // Left side net
+  buildNetGrid(GOAL_DEPTH, GOAL_HEIGHT, -GOAL_WIDTH / 2, 0, 0, zSign > 0 ? -Math.PI / 2 : Math.PI / 2);
+  // Right side net
+  buildNetGrid(GOAL_DEPTH, GOAL_HEIGHT, GOAL_WIDTH / 2, 0, 0, zSign > 0 ? Math.PI / 2 : -Math.PI / 2);
+  // Top net
+  {
+    const cols = Math.round(GOAL_WIDTH / cellSize);
+    const rows = Math.round(GOAL_DEPTH / cellSize);
+    const positions = [];
+    for (let r = 0; r <= rows; r++) {
+      const z = (r / rows) * zSign * GOAL_DEPTH;
+      positions.push(-GOAL_WIDTH / 2, GOAL_HEIGHT, z, GOAL_WIDTH / 2, GOAL_HEIGHT, z);
+    }
+    for (let c = 0; c <= cols; c++) {
+      const x = (c / cols) * GOAL_WIDTH - GOAL_WIDTH / 2;
+      positions.push(x, GOAL_HEIGHT, 0, x, GOAL_HEIGHT, zSign * GOAL_DEPTH);
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    netGroup.add(new THREE.LineSegments(geo, lineMat));
+  }
 }
 
 function addFieldLine(scene, x, z, width, depth, y = 0.01, color = 0xffffff) {


### PR DESCRIPTION
## Summary
Replaced the semi-transparent plane net visualization with a detailed white mesh grid that covers all surfaces of the goal (back, left side, right side, and top).

## Key Changes
- Replaced single semi-transparent `MeshStandardMaterial` plane with `LineBasicMaterial` line segments for a wire-frame grid effect
- Expanded net visualization from back plane only to a complete 3D net structure:
  - Back net (full goal width and height)
  - Left and right side nets (goal depth and height)
  - Top net (goal width and depth)
- Implemented `buildNetGrid()` helper function to generate grid lines with configurable dimensions and rotations
- Changed net color from inherited `color` parameter to fixed white (`0xffffff`) with 0.7 opacity
- Set grid cell size to 0.4 units for consistent spacing across all net surfaces
- Organized all net components under a single `THREE.Group()` for easier positioning and management

## Implementation Details
- Grid lines are generated using `THREE.LineSegments` with `BufferGeometry` for efficient rendering
- Horizontal and vertical lines are calculated based on cell size to create uniform grid patterns
- Side nets use rotation transformations to properly orient them perpendicular to the back plane
- Top net is built with custom positioning logic to account for the z-axis depth variation

https://claude.ai/code/session_01DFH522MQfi77P8XksMmGFf