### PR TITLE
Replace procedural soccer ball texture with GLB model

### DIFF
--- a/soccerBall.js
+++ b/soccerBall.js
@@ -28,13 +28,20 @@ export class SoccerBall {
 
     _ballLoader.load('/assets/props/soccer_ball.glb', (gltf) => {
       const model = gltf.scene;
-      // Scale the GLB so it matches the physics collider radius
-      const box = new THREE.Box3().setFromObject(model);
+      // Scale first so the bounding box reflects final size
+      const box0 = new THREE.Box3().setFromObject(model);
       const size = new THREE.Vector3();
-      box.getSize(size);
+      box0.getSize(size);
       const maxDim = Math.max(size.x, size.y, size.z);
       const scale = (ballRadius * 2) / maxDim;
       model.scale.setScalar(scale);
+      // Re-center: offset the model so its geometric center sits at (0,0,0),
+      // which is the physics body origin. This fixes the orbital-rotation bug
+      // and prevents the ball from floating above its collider.
+      const box1 = new THREE.Box3().setFromObject(model);
+      const center = new THREE.Vector3();
+      box1.getCenter(center);
+      model.position.sub(center);
       model.traverse(child => { if (child.isMesh) child.castShadow = true; });
       this.mesh.add(model);
     });

--- a/soccerBall.js
+++ b/soccerBall.js
@@ -1,7 +1,9 @@
 import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import RAPIER from '@dimforge/rapier3d-compat';
 
 const BALL_RADIUS = 0.28;
+const _ballLoader = new GLTFLoader();
 
 export class SoccerBall {
   constructor(scene, rapierWorld, rbToMesh) {
@@ -17,39 +19,25 @@ export class SoccerBall {
 
   create(x = 0, y = 1, z = 0, sizeMultiplier = 1.0) {
     const ballRadius = BALL_RADIUS * sizeMultiplier;
-    // Build a simple black-and-white soccer ball using canvas texture
-    const canvas = document.createElement('canvas');
-    canvas.width = 256;
-    canvas.height = 256;
-    const ctx = canvas.getContext('2d');
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, 256, 256);
-    ctx.fillStyle = '#111111';
-    // Pentagon-ish patches
-    const patches = [
-      [128, 128], [128, 60], [60, 100], [196, 100],
-      [80, 180], [176, 180]
-    ];
-    for (const [px, py] of patches) {
-      ctx.beginPath();
-      for (let i = 0; i < 5; i++) {
-        const a = (i / 5) * Math.PI * 2 - Math.PI / 2;
-        const r = 28;
-        const cx = px + Math.cos(a) * r;
-        const cy = py + Math.sin(a) * r;
-        i === 0 ? ctx.moveTo(cx, cy) : ctx.lineTo(cx, cy);
-      }
-      ctx.closePath();
-      ctx.fill();
-    }
-    const texture = new THREE.CanvasTexture(canvas);
 
-    const geo = new THREE.SphereGeometry(ballRadius, 16, 16);
-    const mat = new THREE.MeshStandardMaterial({ map: texture, roughness: 0.6 });
-    this.mesh = new THREE.Mesh(geo, mat);
-    this.mesh.castShadow = true;
+    // Placeholder invisible mesh so physics can attach immediately;
+    // replaced by the GLB model once loaded.
+    this.mesh = new THREE.Object3D();
     this.mesh.position.set(x, y, z);
     this.scene.add(this.mesh);
+
+    _ballLoader.load('/assets/props/soccer_ball.glb', (gltf) => {
+      const model = gltf.scene;
+      // Scale the GLB so it matches the physics collider radius
+      const box = new THREE.Box3().setFromObject(model);
+      const size = new THREE.Vector3();
+      box.getSize(size);
+      const maxDim = Math.max(size.x, size.y, size.z);
+      const scale = (ballRadius * 2) / maxDim;
+      model.scale.setScalar(scale);
+      model.traverse(child => { if (child.isMesh) child.castShadow = true; });
+      this.mesh.add(model);
+    });
 
     this.ballRadius = ballRadius;
 


### PR DESCRIPTION
## Summary
Replaced the procedurally generated canvas-based soccer ball texture with a 3D GLB model loaded from assets. This improves visual fidelity while maintaining the same physics behavior.

## Key Changes
- Added GLTFLoader import to load 3D models
- Removed canvas-based texture generation code that created a simple black-and-white pentagon pattern
- Implemented async GLB model loading from `/assets/props/soccer_ball.glb`
- Added automatic scaling logic to match the loaded model to the physics collider radius
- Ensured shadow casting is applied to all mesh children in the loaded model
- Created a temporary Object3D placeholder that gets replaced by the loaded model to allow immediate physics attachment

## Implementation Details
- The soccer ball mesh is initially created as an empty Object3D to allow the physics body to attach immediately
- Once the GLB model loads asynchronously, it's scaled based on its bounding box dimensions to match the expected `ballRadius * 2` size
- All mesh children in the loaded model have `castShadow` enabled for consistent lighting
- The model is added as a child of the placeholder mesh, maintaining the original position and physics behavior

https://claude.ai/code/session_01NGLiCRJXmV4iB9oQFCSawe