### PR TITLE
Skip game setup on page reload after leaving game

### DIFF
--- a/app.js
+++ b/app.js
@@ -3454,6 +3454,7 @@ async function main() {
   });
 
   document.getElementById('leave-game-btn').addEventListener('click', () => {
+    sessionStorage.setItem('skipToGame', '1');
     window.location.reload();
   });
 


### PR DESCRIPTION
## Summary
Added session storage flag to skip the game setup flow when the page is reloaded after a user leaves an active game.

## Key Changes
- Set `skipToGame` flag in sessionStorage before reloading the page when the "leave game" button is clicked
- This allows the application to detect on reload that the user was in a game session and can skip initial setup steps

## Implementation Details
The flag is stored in sessionStorage (rather than localStorage) so it persists only for the current browser session/tab and is automatically cleared when the tab is closed. This ensures the skip behavior only applies to the immediate reload following a game exit, not to subsequent page visits.

https://claude.ai/code/session_018NrS3UuFJ541NYaZSw1azZ