### PR TITLE
Fix inverted arrow key controls for camera rotation

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -839,8 +839,8 @@ export class PlayerControls {
     }
 
     const rotateSpeed = 0.03;
-    if (this.keys.has('ArrowLeft')) this.yaw += rotateSpeed;
-    if (this.keys.has('ArrowRight')) this.yaw -= rotateSpeed;
+    if (this.keys.has('ArrowLeft')) this.yaw -= rotateSpeed;
+    if (this.keys.has('ArrowRight')) this.yaw += rotateSpeed;
 
     const maxPitch = Math.PI / 3;   // ~60° upward
     const minPitch = -Math.PI / 8;  // ~30° downward


### PR DESCRIPTION
## Summary
Fixed inverted left/right arrow key controls for camera yaw rotation in the player controls system.

## Changes
- Swapped the yaw rotation direction for left and right arrow keys to match expected behavior
  - Left arrow now correctly decreases yaw (rotates camera left)
  - Right arrow now correctly increases yaw (rotates camera right)

## Details
The arrow key bindings for horizontal camera rotation were inverted, causing the camera to rotate in the opposite direction of user input. This change corrects the mapping so that pressing the left arrow key rotates the camera left and the right arrow key rotates the camera right, providing intuitive camera control behavior.

https://claude.ai/code/session_01MtEaUpwLCw7LasNrSuBG6S