### PR TITLE
Fix match join countdown to use latest bracket data

### DIFF
--- a/app.js
+++ b/app.js
@@ -928,6 +928,7 @@ async function main() {
     let unsubBracket = null;
     let joinConfirmed = false;
     let gameStarted = false;
+    let latestBracket = null;
 
     function cleanup() {
       if (joinCountdownTimer) clearInterval(joinCountdownTimer);
@@ -991,6 +992,9 @@ async function main() {
         const joined = match.joinedPlayers || {};
         const joinedCount = realPlayers.filter(p => joined[p]).length;
 
+        // Always keep latestBracket fresh so the timer callback uses up-to-date joinedPlayers
+        latestBracket = tData.bracket;
+
         statusMsg.textContent = `YOUR MATCH: ${myMatchInfo.myTeam.name} vs ${myMatchInfo.opponentTeam.name}`;
         statusMsg.style.color = '#ffcc44';
 
@@ -1012,10 +1016,16 @@ async function main() {
             if (countdownEl) countdownEl.textContent = fmtMs(left);
             if (left <= 0) {
               clearInterval(joinCountdownTimer);
-              // Kick non-joined players and start
-              await kickAndFillBots(tid, matchId, tData.bracket).catch(() => {});
+              // Kick non-joined players and start; use latestBracket so joinedPlayers is current
+              await kickAndFillBots(tid, matchId, latestBracket).catch(() => {});
             }
           }, 500);
+        }
+
+        // Skip the countdown if all real players have already joined
+        if (joinConfirmed && realPlayers.length > 0 && joinedCount >= realPlayers.length) {
+          if (joinCountdownTimer) clearInterval(joinCountdownTimer);
+          await kickAndFillBots(tid, matchId, tData.bracket).catch(() => {});
         }
       }
     });


### PR DESCRIPTION
## Summary
Fixed a race condition in the match join countdown logic where stale bracket data could be used when kicking non-joined players and starting the match.

## Key Changes
- Added `latestBracket` variable to track the most recent bracket state from polling updates
- Updated the bracket reference in the countdown timer callback to use `latestBracket` instead of potentially stale `tData.bracket`
- Added early exit logic to skip the countdown timer if all real players have already joined, immediately proceeding to kick non-joined players and start the match

## Implementation Details
- The `latestBracket` variable is refreshed on every bracket data update, ensuring the timer callback always has current `joinedPlayers` information
- The new early-exit condition checks if all real players have confirmed their join status and immediately triggers match start without waiting for the full countdown
- Both code paths now use up-to-date bracket data when calling `kickAndFillBots()`

https://claude.ai/code/session_01BGpTMkj7fCfd4jsJN9vxoF