### PR TITLE
Fix inverted left/right movement controls

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -693,8 +693,8 @@ export class PlayerControls {
       } else {
         if (this.keysPressed.has("w")) moveDirection.z = 1;
         if (this.keysPressed.has("s")) moveDirection.z = -1;
-        if (this.keysPressed.has("a")) moveDirection.x = 1;
-        if (this.keysPressed.has("d")) moveDirection.x = -1;
+        if (this.keysPressed.has("a")) moveDirection.x = -1;
+        if (this.keysPressed.has("d")) moveDirection.x = 1;
       }
     }
     if (!this.isMobile && moveDirection.length() > 0) moveDirection.normalize();


### PR DESCRIPTION
## Summary
Fixed inverted horizontal movement controls in the player movement system. The "A" and "D" keys were mapped to opposite directions than intended.

## Changes
- Corrected "A" key mapping from `moveDirection.x = 1` to `moveDirection.x = -1` (move left)
- Corrected "D" key mapping from `moveDirection.x = -1` to `moveDirection.x = 1` (move right)

## Details
The horizontal movement controls were inverted, causing players to move right when pressing "A" (left) and left when pressing "D" (right). This fix aligns the controls with standard WASD movement conventions where "A" moves left and "D" moves right.

https://claude.ai/code/session_01384nCvGHHiJMB9dZkDcNGS