### PR TITLE
Fix camera right vector calculation in player controls

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -703,7 +703,7 @@ export class PlayerControls {
       : (() => { const v = new THREE.Vector3(); this.camera.getWorldDirection(v); v.y = 0; v.normalize(); return v; })();
     const rightVector = this.followBallCameraRight
       ? this.followBallCameraRight.clone()
-      : new THREE.Vector3().crossVectors(this.camera.up, cameraDirection).normalize();
+      : new THREE.Vector3().crossVectors(cameraDirection, new THREE.Vector3(0, 1, 0)).normalize();
     const movement = new THREE.Vector3();
     if (!this.isMobile) {
       if (moveDirection.z !== 0) movement.add(cameraDirection.clone().multiplyScalar(moveDirection.z));


### PR DESCRIPTION
## Summary
Fixed the calculation of the right vector for camera-relative movement in player controls by correcting the cross product operand order.

## Key Changes
- Changed the cross product calculation from `crossVectors(this.camera.up, cameraDirection)` to `crossVectors(cameraDirection, new THREE.Vector3(0, 1, 0))`
- This ensures the right vector is computed correctly relative to the camera's forward direction and world up axis

## Implementation Details
The cross product order matters for directional vectors. The previous implementation used `camera.up` which could be affected by camera roll, whereas the corrected version uses the world up vector (0, 1, 0) consistently. This produces the correct rightward direction perpendicular to both the camera's forward direction and the world vertical axis, which is essential for proper camera-relative movement controls.

https://claude.ai/code/session_01TqDL7wW5gZ4mQdrCD9TixR