### PR TITLE
Preserve ball camera state during throw-in sequences

### DIFF
--- a/app.js
+++ b/app.js
@@ -1962,10 +1962,11 @@ async function main() {
 
   // Throw-in hand-holding state (local player is the taker)
   const throwInState = {
-    holding: false,     // ball is held at player's hand
-    handBone: null,     // THREE.Bone for right hand
-    button: null,       // DOM button element
-    thrown: false,      // animation triggered, waiting for release
+    holding: false,              // ball is held at player's hand
+    handBone: null,              // THREE.Bone for right hand
+    button: null,                // DOM button element
+    thrown: false,               // animation triggered, waiting for release
+    wasFollowBallCamera: false,  // ball camera was active before throw-in
   };
 
   // Bot throw-in state (an AI player is the taker)
@@ -2521,6 +2522,13 @@ async function main() {
     throwInState.holding = true;
     throwInState.thrown = false;
 
+    // Temporarily disable ball camera during throw-in
+    if (followBallCamera) {
+      throwInState.wasFollowBallCamera = true;
+      followBallCamera = false;
+      followBallBtn.classList.remove('active');
+    }
+
     // Find hand bone inside the player model
     if (playerModel) {
       throwInState.handBone = findRightHandBone(playerModel);
@@ -2583,6 +2591,13 @@ async function main() {
 
       // Remove button
       clearThrowInButton();
+
+      // Restore ball camera if it was active before throw-in
+      if (throwInState.wasFollowBallCamera) {
+        throwInState.wasFollowBallCamera = false;
+        followBallCamera = true;
+        followBallBtn.classList.add('active');
+      }
     }, 600);
   }
 
@@ -2595,6 +2610,12 @@ async function main() {
   }
 
   function clearThrowIn() {
+    // Restore ball camera if it was suppressed for the throw-in
+    if (throwInState.wasFollowBallCamera) {
+      throwInState.wasFollowBallCamera = false;
+      followBallCamera = true;
+      followBallBtn.classList.add('active');
+    }
     throwInState.holding = false;
     throwInState.thrown = false;
     throwInState.handBone = null;


### PR DESCRIPTION
## Summary
This change ensures that the ball camera (follow ball camera) is temporarily disabled during throw-in sequences and properly restored afterward, preventing camera conflicts during player-controlled throw-in animations.

## Key Changes
- Added `wasFollowBallCamera` flag to `throwInState` object to track whether ball camera was active before throw-in initiation
- When a throw-in begins, the ball camera is now disabled and its previous state is saved
- After throw-in completion (both successful throws and cancellations), the ball camera is restored to its previous state
- Camera restoration logic is implemented in two places:
  - In the throw animation completion handler (after 600ms delay)
  - In the `clearThrowIn()` function (for early cancellations)

## Implementation Details
- The flag prevents the ball camera from interfering with the throw-in hand-holding animation
- Both code paths that exit throw-in state (successful throw and cancellation) properly restore the camera setting
- The UI button state (`followBallBtn`) is also synchronized when toggling the camera state

https://claude.ai/code/session_0115hGunBr9bMPGvAarK8WAw