### PR TITLE
Spawn furthest-forward defender on goal instead of first bot

### DIFF
--- a/app.js
+++ b/app.js
@@ -2240,9 +2240,10 @@ async function main() {
       // Reset players to their sides
       _resetPlayersToSides();
 
-      // Spawn one defender from the team that conceded near center
+      // Spawn the furthest-forward bot from the team that conceded near center
       const defendingTeam = scoringTeam === 'home' ? 'away' : 'home';
-      const defAI = aiPlayers[defendingTeam]?.[0];
+      const defTeamBots = aiPlayers[defendingTeam] ?? [];
+      const defAI = defTeamBots[defTeamBots.length - 1];
       if (defAI?.body) {
         defAI.body.setTranslation({ x: (Math.random() - 0.5) * 6, y: 1.5, z: (defendingTeam === 'home' ? -3 : 3) }, true);
         defAI.body.setLinvel({ x: 0, y: 0, z: 0 }, true);


### PR DESCRIPTION
## Summary
Modified the goal respawn logic to spawn the furthest-forward bot from the defending team near the center, rather than always spawning the first bot in the array.

## Key Changes
- Changed defender selection from `aiPlayers[defendingTeam]?.[0]` (first bot) to `defTeamBots[defTeamBots.length - 1]` (last bot)
- Added intermediate variable `defTeamBots` to safely access the defending team's bot array with fallback to empty array
- Updated comment to reflect that the "furthest-forward bot" is now being spawned

## Implementation Details
The change assumes that bots in the `aiPlayers` array are ordered by their forward position, with the last element being the furthest-forward player. This makes tactical sense for goal replays, as it spawns a more advanced defender closer to the goal rather than a goalkeeper or defensive midfielder.

https://claude.ai/code/session_01Ff64B828w24GqnRtQWmq1G