### PR TITLE
Remove melee punch attack mechanics and mobile UI button

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -340,21 +340,6 @@ export class PlayerControls {
       }, { passive: false });
     }
 
-    // Punch button
-    if (!document.getElementById('punch-button')) {
-      const punchButton = document.createElement('button');
-      punchButton.id = 'punch-button';
-      punchButton.className = 'action-button mobile-action';
-      punchButton.innerText = 'PUNCH';
-      actionContainer.appendChild(punchButton);
-      punchButton.addEventListener('touchstart', (event) => {
-        if (!this.enabled || this.isInWater) return;
-        this.playAction('mutantPunch');
-        this.audioManager?.playPunch();
-        event.preventDefault();
-      });
-    }
-
     // Slide button
     if (!document.getElementById('slide-button')) {
       const slideButton = document.createElement('button');
@@ -409,15 +394,6 @@ export class PlayerControls {
           this.hasDoubleJumped = true;
           this.playAction('hurricaneKick');
         }
-      } else if (key === 'q') {
-        if (this.isInWater) return;
-        if (this.isMoving) {
-          this.slideMomentum.copy(this.lastMoveDirection).multiplyScalar(0.5);
-        } else {
-          this.slideMomentum.set(0, 0, 0);
-        }
-        this.playAction('mutantPunch');
-        this.audioManager?.playPunch();
       } else if (key === 'e') {
         if (this.isInWater) return;
         this.slideMomentum.set(0, 0, 0);

--- a/melee.js
+++ b/melee.js
@@ -24,30 +24,6 @@ export function updateMeleeAttacks({ playerModel, otherPlayers, audioManager }) 
     const elapsed = now - info.start;
     if (elapsed >= cfg.hitTime && elapsed <= cfg.hitTime + cfg.hitWindow && !info.hasHit) {
       let hit = false;
-      let playerHit = false;
-      if (cfg.damage > 0) {
-        for (const target of players) {
-          if (target === attacker) continue;
-          const dist = attacker.model.position.distanceTo(target.model.position);
-          if (dist <= cfg.range) {
-            hit = true;
-            playerHit = true;
-            if (target.id === 'local') {
-              window.localHealth = Math.max(0, window.localHealth - cfg.damage);
-              if (window.playerControls) {
-                const dir = new THREE.Vector3().subVectors(target.model.position, attacker.model.position).normalize();
-                const impulse = dir.multiplyScalar(0.15);
-                window.playerControls.applyKnockback(impulse);
-              }
-            } else {
-              const tp = otherPlayers[target.id];
-              if (tp) {
-                tp.health = Math.max(0, (tp.health || 100) - cfg.damage);
-              }
-            }
-          }
-        }
-      }
 
       if (window.soccerBall?.body) {
         const ballPos = window.soccerBall.getPosition();
@@ -96,9 +72,6 @@ export function updateMeleeAttacks({ playerModel, otherPlayers, audioManager }) 
         }
       }
 
-      if (playerHit) {
-        audioManager?.playSFX('SFX/Footsteps/Dirt/Dirt Run 1.ogg', 0.6);
-      }
       if (hit) {
         info.hasHit = true;
       }


### PR DESCRIPTION
## Summary
This PR removes the melee punch attack system from the game, including player damage logic, knockback effects, audio feedback, and the associated mobile UI button and keyboard control.

## Key Changes
- **melee.js**: Removed player damage calculation and knockback application during melee attacks
  - Deleted logic that dealt damage to local and remote players within attack range
  - Removed knockback impulse application to the local player
  - Removed audio SFX trigger for successful player hits
  - Kept soccer ball interaction logic intact

- **controls.js**: Removed punch action input handling
  - Deleted mobile "PUNCH" button UI element and its touch event listener
  - Removed 'Q' key binding for punch action
  - Kept other action buttons (slide, etc.) and keyboard controls intact

## Implementation Details
The changes preserve the overall melee attack system structure (hit detection timing, soccer ball interactions) while completely removing the player-vs-player combat functionality. This appears to be a shift away from PvP melee combat mechanics while maintaining other gameplay systems.

https://claude.ai/code/session_01SgNjpcyLT3iRBrPdKCxidP