### PR TITLE
Remove double jump mechanic and fix jump physics

### DIFF
--- a/controls.js
+++ b/controls.js
@@ -59,7 +59,6 @@ export class PlayerControls {
     this.canJump = true;
     this.keysPressed = new Set();
     this.isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-    this.hasDoubleJumped = false;
     this.currentSpecialAction = null;
     this.runningKickTimer = null;
     this.runningKickOriginalY = 0;
@@ -197,7 +196,8 @@ export class PlayerControls {
       if (!this.enabled || this.isInWater) return;
       this.jumpButtonPressed = true;
       if (this.canJump && this.body) {
-        this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+        const vel = this.body.linvel();
+        this.body.setLinvel({ x: vel.x, y: JUMP_FORCE, z: vel.z }, true);
         this.canJump = false;
         setTimeout(() => this._trySoccerHeader(), 350);
       }
@@ -385,14 +385,10 @@ export class PlayerControls {
         }
         if (this.isInWater) return;
         if (this.canJump && this.body) {
-          this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+          const vel = this.body.linvel();
+          this.body.setLinvel({ x: vel.x, y: JUMP_FORCE, z: vel.z }, true);
           this.canJump = false;
-          this.hasDoubleJumped = false;
           setTimeout(() => this._trySoccerHeader(), 350);
-        } else if (!this.hasDoubleJumped && this.body) {
-          this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
-          this.hasDoubleJumped = true;
-          this.playAction('hurricaneKick');
         }
       } else if (key === 'e') {
         if (this.isInWater) return;
@@ -625,7 +621,6 @@ export class PlayerControls {
     const grounded = !this.isInWater && t.y <= groundExpectedY + 0.05;
     if (grounded && !this.isInWater) {
       this.canJump = true;
-      this.hasDoubleJumped = false;
     } else {
       this.canJump = false;
     }
@@ -1007,7 +1002,8 @@ export class PlayerControls {
   triggerJump() {
     if (!this.enabled || !this.body) return;
     if (this.canJump) {
-      this.body.applyImpulse({ x: 0, y: JUMP_FORCE, z: 0 }, true);
+      const vel = this.body.linvel();
+      this.body.setLinvel({ x: vel.x, y: JUMP_FORCE, z: vel.z }, true);
       this.canJump = false;
     }
   }


### PR DESCRIPTION
## Summary
This PR removes the double jump (hurricane kick) mechanic and refactors jump physics to use velocity setting instead of impulse application for more consistent jump behavior.

## Key Changes
- **Removed double jump mechanic**: Eliminated `hasDoubleJumped` flag and associated logic that allowed players to perform a second jump in mid-air with the hurricane kick action
- **Refactored jump physics**: Changed from `applyImpulse()` to `setLinvel()` for all jump triggers to ensure consistent vertical velocity regardless of current momentum
  - Updated jump handling in `onKeyDown()` method
  - Updated jump handling in space bar press logic
  - Updated `triggerJump()` method
- **Preserved horizontal momentum**: Jump refactoring maintains the player's existing horizontal velocity while setting a fixed vertical jump velocity

## Implementation Details
The jump physics change replaces impulse-based jumping (which adds force on top of existing velocity) with direct velocity setting (which sets the vertical component to a fixed value). This provides more predictable and consistent jump behavior. The horizontal velocity components are preserved to maintain player momentum during jumps.

https://claude.ai/code/session_017xPJUSfc5WHHjhtAFtsr7H