### PR TITLE
Add purchasable move upgrades with unlock gates

### DIFF
--- a/app.js
+++ b/app.js
@@ -486,13 +486,21 @@ async function main() {
     let shopCoins = 0;
 
     function applyUpgradeFlag(key) {
-      if (key === 'rainbowTrail') window.hasRainbowTrail = true;
-      if (key === 'moveRoll') window.hasMoveRoll = true;
-      if (key === 'moveSprint') window.hasMoveSprint = true;
-      if (key === 'moveSlide') window.hasMoveSlide = true;
-      if (key === 'moveLob') window.hasMoveLob = true;
-      if (key === 'moveJump') window.hasMoveJump = true;
-      if (key === 'moveBicycle') window.hasMoveBicycle = true;
+      if (key === 'rainbowTrail') { window.hasRainbowTrail = true; return; }
+      const moveMap = {
+        moveRoll:    ['hasMoveRoll',    'roll-button'],
+        moveSprint:  ['hasMoveSprint',  'sprint-button'],
+        moveSlide:   ['hasMoveSlide',   'slide-button'],
+        moveLob:     ['hasMoveLob',     'lob-button'],
+        moveJump:    ['hasMoveJump',    'jump-button'],
+        moveBicycle: ['hasMoveBicycle', 'bicycle-button'],
+      };
+      const entry = moveMap[key];
+      if (entry) {
+        window[entry[0]] = true;
+        const btn = document.getElementById(entry[1]);
+        if (btn) btn.style.display = '';
+      }
     }
 
     async function openShopOverlay() {

--- a/app.js
+++ b/app.js
@@ -438,10 +438,62 @@ async function main() {
         emoji: '🌈',
         cost: 100,
       },
+      {
+        key: 'moveRoll',
+        name: 'ROLL',
+        desc: 'ROLL FORWARD TO DODGE\nAND REACH THE BALL!',
+        emoji: '🔄',
+        cost: 25,
+      },
+      {
+        key: 'moveSprint',
+        name: 'SPRINT',
+        desc: 'DASH FASTER THAN YOUR\nOPPONENTS TO THE BALL!',
+        emoji: '💨',
+        cost: 40,
+      },
+      {
+        key: 'moveSlide',
+        name: 'SLIDE',
+        desc: 'SLIDE TACKLE TO STEAL\nTHE BALL FROM ENEMIES!',
+        emoji: '🛝',
+        cost: 100,
+      },
+      {
+        key: 'moveLob',
+        name: 'LOB',
+        desc: 'LAUNCH THE BALL IN A\nHIGH ARC OVER THE FIELD!',
+        emoji: '🏈',
+        cost: 150,
+      },
+      {
+        key: 'moveJump',
+        name: 'JUMP',
+        desc: 'LEAP INTO THE AIR AND\nHEAD THE BALL TO SCORE!',
+        emoji: '⬆️',
+        cost: 250,
+      },
+      {
+        key: 'moveBicycle',
+        name: 'BICYCLE KICK',
+        desc: 'PERFORM A STUNNING\nBICYCLE KICK OVERHEAD!',
+        emoji: '🚲',
+        cost: 500,
+      },
     ];
 
     let playerUpgrades = {};
     let shopCoins = 0;
+
+    function applyUpgradeFlag(key) {
+      if (key === 'rainbowTrail') window.hasRainbowTrail = true;
+      if (key === 'moveRoll') window.hasMoveRoll = true;
+      if (key === 'moveSprint') window.hasMoveSprint = true;
+      if (key === 'moveSlide') window.hasMoveSlide = true;
+      if (key === 'moveLob') window.hasMoveLob = true;
+      if (key === 'moveJump') window.hasMoveJump = true;
+      if (key === 'moveBicycle') window.hasMoveBicycle = true;
+    }
 
     async function openShopOverlay() {
       const shopOverlay = document.getElementById('shop-overlay');
@@ -493,10 +545,7 @@ async function main() {
               playerUpgrades[upgrade.key] = true;
               shopCoins -= upgrade.cost;
               document.getElementById('shop-coins-display').textContent = `🪙 ${shopCoins}`;
-              // If rainbow trail was just purchased, activate it
-              if (upgrade.key === 'rainbowTrail') {
-                window.hasRainbowTrail = true;
-              }
+              applyUpgradeFlag(upgrade.key);
               renderShopItems(listEl);
             } catch (err) {
               if (err.message === 'NOT_ENOUGH_COINS') {
@@ -676,11 +725,11 @@ async function main() {
       }
     });
 
-    // Preload upgrade state so the trail activates on game start if already owned
+    // Preload upgrade state so upgrades activate on game start if already owned
     (async () => {
       try {
         const upgrades = await getUserUpgrades(getSession());
-        if (upgrades?.rainbowTrail) window.hasRainbowTrail = true;
+        if (upgrades) Object.keys(upgrades).forEach(k => { if (upgrades[k]) applyUpgradeFlag(k); });
       } catch { /* ignore */ }
     })();
 
@@ -3393,11 +3442,11 @@ async function main() {
     button.addEventListener('mousedown', handler);
   };
 
-  bindActionButton('roll-button', () => playerControls.triggerRoll());
-  bindActionButton('slide-button', () => playerControls.triggerSlide());
-  bindActionButton('sprint-button', () => playerControls.triggerSprint());
-  bindActionButton('lob-button', () => playerControls.playAction('farKick'));
-  bindActionButton('bicycle-button', () => playerControls.playAction('bicycleKick'));
+  bindActionButton('roll-button', () => { if (window.hasMoveRoll) playerControls.triggerRoll(); });
+  bindActionButton('slide-button', () => { if (window.hasMoveSlide) playerControls.triggerSlide(); });
+  bindActionButton('sprint-button', () => { if (window.hasMoveSprint) playerControls.triggerSprint(); });
+  bindActionButton('lob-button', () => { if (window.hasMoveLob) playerControls.playAction('farKick'); });
+  bindActionButton('bicycle-button', () => { if (window.hasMoveBicycle) playerControls.playAction('bicycleKick'); });
 
   let localStream = null;
   let micActive = false;

--- a/controls.js
+++ b/controls.js
@@ -193,7 +193,7 @@ export class PlayerControls {
     
     // Jump button event listeners
     document.getElementById('jump-button').addEventListener('touchstart', (event) => {
-      if (!this.enabled || this.isInWater) return;
+      if (!this.enabled || this.isInWater || !window.hasMoveJump) return;
       this.jumpButtonPressed = true;
       if (this.canJump && this.body) {
         const vel = this.body.linvel();
@@ -385,6 +385,7 @@ export class PlayerControls {
           return;
         }
         if (this.isInWater) return;
+        if (!window.hasMoveJump) return;
         if (this.canJump && this.body) {
           const vel = this.body.linvel();
           this.body.setLinvel({ x: vel.x, y: JUMP_FORCE, z: vel.z }, true);
@@ -398,19 +399,24 @@ export class PlayerControls {
         this.audioManager?.playAttack();
       } else if (key === 'f') {
         if (this.isInWater) return;
+        if (!window.hasMoveLob) return;
         this.slideMomentum.set(0, 0, 0);
         this.playAction('farKick');
         this.audioManager?.playAttack?.();
       } else if (key === 'v') {
         if (this.isInWater) return;
+        if (!window.hasMoveBicycle) return;
         this.slideMomentum.set(0, 0, 0);
         this.playAction('bicycleKick');
         this.audioManager?.playAttack?.();
       } else if (key === 'r') {
+        if (!window.hasMoveRoll) return;
         this.triggerRoll();
       } else if (key === 'z') {
+        if (!window.hasMoveSlide) return;
         this.triggerSlide();
       } else if (key === 'shift') {
+        if (!window.hasMoveSprint) return;
         this.triggerSprint();
       } else if (key === 'g') {
         if (this.grabbedTarget) {

--- a/index.html
+++ b/index.html
@@ -20,12 +20,12 @@
   <div id="action-buttons">
     <button id="mobile-action-toggle" class="action-button mobile-only" aria-expanded="false" aria-label="Toggle actions">⋯</button>
     <button id="voice-button" class="action-button mobile-action">Unmute</button>
-    <button id="roll-button" class="action-button mobile-action">ROLL</button>
-    <button id="slide-button" class="action-button mobile-action">SLIDE</button>
-    <button id="sprint-button" class="action-button mobile-action">SPRINT</button>
-    <button id="lob-button" class="action-button mobile-action">LOB</button>
-    <button id="jump-button" class="action-button mobile-action">JUMP</button>
-    <button id="bicycle-button" class="action-button mobile-action">BICYCLE</button>
+    <button id="roll-button" class="action-button mobile-action" style="display:none">ROLL</button>
+    <button id="slide-button" class="action-button mobile-action" style="display:none">SLIDE</button>
+    <button id="sprint-button" class="action-button mobile-action" style="display:none">SPRINT</button>
+    <button id="lob-button" class="action-button mobile-action" style="display:none">LOB</button>
+    <button id="jump-button" class="action-button mobile-action" style="display:none">JUMP</button>
+    <button id="bicycle-button" class="action-button mobile-action" style="display:none">BICYCLE</button>
     <button id="kick-button" class="action-button mobile-only">KICK</button>
   </div>
   


### PR DESCRIPTION
## Summary
This PR implements a shop system for purchasable player movement abilities. Players can now buy special moves (Roll, Sprint, Slide, Lob, Jump, Bicycle Kick) from the shop, and these moves are gated behind ownership checks to prevent use before purchase.

## Key Changes
- **Added 6 new purchasable upgrades** to the shop: moveRoll, moveSprint, moveSlide, moveLob, moveJump, and moveBicycle, each with unique descriptions, emojis, and costs (25-500 coins)
- **Created `applyUpgradeFlag()` function** to centralize upgrade activation logic, setting corresponding `window.has*` flags when upgrades are purchased or preloaded
- **Added ownership gates** to all move triggers in `controls.js`:
  - Jump button and keyboard 'w' key now check `window.hasMoveJump`
  - Lob action ('f' key) checks `window.hasMoveLob`
  - Bicycle kick ('v' key) checks `window.hasMoveBicycle`
  - Roll ('r' key) checks `window.hasMoveRoll`
  - Slide ('z' key) checks `window.hasMoveSlide`
  - Sprint ('shift' key) checks `window.hasMoveSprint`
- **Updated action button bindings** in `app.js` to check ownership flags before executing move actions
- **Improved upgrade preloading** to apply all owned upgrades on game start, not just the rainbow trail

## Implementation Details
- Upgrade flags are stored as window properties and persist across game sessions via the backend
- The `applyUpgradeFlag()` function is called both when purchasing upgrades and when preloading user data
- All move actions now fail silently if the player hasn't purchased the corresponding upgrade, preventing unintended behavior

https://claude.ai/code/session_01LR8D2UoZHESDcFSRVXYURB