### PR TITLE
Attach top hat to head bone for proper animation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1951,9 +1951,17 @@ async function main() {
     const brim = new THREE.Mesh(new THREE.CylinderGeometry(0.30, 0.30, 0.03, 16), mat);
     brim.position.y = 0;
     group.add(brim);
-    // Position at head height within the playerGroup
-    group.position.y = 1.48;
     return group;
+  }
+
+  function findHeadBone(model) {
+    let bone = null;
+    model.traverse((obj) => {
+      if (bone) return;
+      const n = obj.name.toLowerCase();
+      if (obj.isBone && n.includes('head')) bone = obj;
+    });
+    return bone;
   }
 
   function updateTopHat(model, hasHat) {
@@ -1961,8 +1969,19 @@ async function main() {
     if (hasHat) {
       if (!model.userData.topHat) {
         const hat = createTopHatMesh();
-        model.add(hat);
+        const headBone = findHeadBone(model);
+        if (headBone) {
+          // Attach to head bone so the hat moves with the head animation
+          headBone.add(hat);
+          // Local offset: sit on top of the head bone
+          hat.position.set(0, 0.18, 0);
+        } else {
+          // Fallback: fixed position on model root
+          model.add(hat);
+          hat.position.y = 1.48;
+        }
         model.userData.topHat = hat;
+        model.userData.topHatParent = headBone || model;
       }
       model.userData.topHat.visible = true;
     } else {


### PR DESCRIPTION
## Summary
Improved top hat positioning by attaching it to the character's head bone when available, allowing the hat to move naturally with head animations instead of remaining in a fixed position.

## Key Changes
- Added `findHeadBone()` function to locate the head bone in the character model by traversing the skeleton and matching bone names containing "head"
- Modified `updateTopHat()` to attach the hat to the head bone when found, with a local offset of 0.18 units on the Y-axis to position it on top of the head
- Implemented fallback behavior that attaches the hat to the model root at a fixed position (1.48 units) when no head bone is found
- Removed the hardcoded hat position from `createTopHatMesh()` to allow dynamic positioning based on attachment point
- Added tracking of the hat's parent bone/object in `model.userData.topHatParent` for potential future use

## Implementation Details
- The head bone detection is case-insensitive and searches for any bone with "head" in its name
- The hat now inherits animations from the head bone, ensuring it stays properly positioned during character animations
- The fallback mechanism ensures backward compatibility with models that lack a proper skeleton structure

https://claude.ai/code/session_01Kjuor7HNbC3qACXDL1FnMz