### PR TITLE
Make hat position configurable per player model

### DIFF
--- a/app.js
+++ b/app.js
@@ -1975,7 +1975,8 @@ async function main() {
         // Mixamo rigs are in centimeter space (~100x world scale),
         // so scale the hat up and offset above the head bone origin
         hat.scale.setScalar(100);
-        hat.position.set(0, 18, 0);
+        const hp = model.userData.hatPosition ?? { x: 0, y: 18, z: 0 };
+        hat.position.set(hp.x, hp.y, hp.z);
         model.userData.topHat = hat;
       }
       model.userData.topHat.visible = true;

--- a/models/playerModel.js
+++ b/models/playerModel.js
@@ -238,6 +238,7 @@ const brightness = config.brightness ?? 1.0;
           pivot.add(model);
           playerGroup.add(pivot);
           playerGroup.userData.pivot = pivot;
+          if (config.hat_position) playerGroup.userData.hatPosition = config.hat_position;
 
           const mixer = new THREE.AnimationMixer(model);
           const actions = {};


### PR DESCRIPTION
## Summary
This change makes the hat positioning system configurable on a per-model basis, allowing different player models to have hats positioned at different heights or offsets rather than using a hardcoded position.

## Key Changes
- Modified `app.js` to read hat position from model configuration with a fallback to the default position (0, 18, 0)
- Updated `playerModel.js` to pass `hat_position` from the model config to the player group's userData
- Hat position is now determined by `model.userData.hatPosition` if provided, otherwise defaults to the original hardcoded values

## Implementation Details
- The hat position is stored in the model's userData during initialization in `playerModel.js`
- In `app.js`, the hat positioning logic now uses the nullish coalescing operator (`??`) to check for a custom position before falling back to defaults
- This maintains backward compatibility - models without a `hat_position` config will continue to use the original position

https://claude.ai/code/session_012TXFMFagqnRMV1ymThsZZv