### PR TITLE
Fix hat scaling to account for player model scale variance

### DIFF
--- a/app.js
+++ b/app.js
@@ -1972,9 +1972,12 @@ async function main() {
         if (!headBone) return; // bones not loaded yet — retry next frame
         const hat = createTopHatMesh();
         headBone.add(hat);
-        // Mixamo rigs are in centimeter space (~100x world scale),
-        // so scale the hat up and offset above the head bone origin
-        hat.scale.setScalar(100);
+        // Mixamo rigs are in centimeter space (~100x world scale).
+        // Divide by the bone's inherited world scale so the hat renders
+        // at the same size regardless of each player model's scale value.
+        const boneWorldScale = new THREE.Vector3();
+        headBone.getWorldScale(boneWorldScale);
+        hat.scale.setScalar(100 / boneWorldScale.x);
         const hp = model.userData.hatPosition ?? { x: 0, y: 18, z: 0 };
         hat.position.set(hp.x, hp.y, hp.z);
         model.userData.topHat = hat;


### PR DESCRIPTION
## Summary
Updated hat scaling logic to normalize for individual player model scale variations, ensuring hats render at a consistent size regardless of each character's scale value.

## Key Changes
- Modified hat scaling calculation to divide the base centimeter-space scale (100) by the head bone's inherited world scale
- Added `getWorldScale()` call to retrieve the bone's actual world scale factor
- Updated comments to clarify the scaling normalization approach

## Implementation Details
Previously, the hat was always scaled by a fixed factor of 100 to account for Mixamo rigs being in centimeter space. However, this didn't account for cases where individual player models might have different scale values applied to their bones. The fix now dynamically adjusts the hat scale based on the head bone's world scale, ensuring consistent hat sizing across all player models regardless of their inherent scale differences.

https://claude.ai/code/session_01B5pom8ZMGPxatkziS8w1oW